### PR TITLE
Removing namespaces from constraint modules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/src/constraints/any.ts
+++ b/src/constraints/any.ts
@@ -1,201 +1,199 @@
 import {Reference, Schema, ValidationOptions, WhenOptions} from "joi";
 import {constraintDecorator, typeConstraintDecorator} from "../core";
 
-export namespace AnyConstraints {
-    export function Allow(...values : any[]) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.allow(values);
-        });
-    }
+export function Allow(...values : any[]) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.allow(values);
+    });
+}
 
-    export function AnySchema() : PropertyDecorator {
-        return typeConstraintDecorator([Number], (Joi : { any : () => Schema }) => {
-            return Joi.any();
-        });
-    }
+export function AnySchema() : PropertyDecorator {
+    return typeConstraintDecorator([Number], (Joi : { any : () => Schema }) => {
+        return Joi.any();
+    });
+}
 
-    /**
-     * Returns a new type that is the result of adding the rules of one type to another.
-     */
-    export function Concat(schema : Schema) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.concat(schema);
-        });
-    }
+/**
+ * Returns a new type that is the result of adding the rules of one type to another.
+ */
+export function Concat(schema : Schema) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.concat(schema);
+    });
+}
 
-    /**
-     * Sets a default value if the original value is undefined.
-     */
-    export function Default(value? : any, description? : string) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.default(value, description);
-        });
-    }
+/**
+ * Sets a default value if the original value is undefined.
+ */
+export function Default(value? : any, description? : string) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.default(value, description);
+    });
+}
 
-    /**
-     * Annotates the key where:
-     * @param desc - the description string.
-     */
-    export function Description(desc : string) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.description(desc);
-        });
-    }
+/**
+ * Annotates the key where:
+ * @param desc - the description string.
+ */
+export function Description(desc : string) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.description(desc);
+    });
+}
 
-    /**
-     * Outputs the original untouched value instead of the casted value.
-     */
-    export function Empty(schema : any) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.empty(schema);
-        });
-    }
+/**
+ * Outputs the original untouched value instead of the casted value.
+ */
+export function Empty(schema : any) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.empty(schema);
+    });
+}
 
-    /**
-     * Annotates the key where:
-     * @param value - an example value.
-     * If the example fails to pass validation, the function will throw.
-     */
-    export function Example(value : any) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.example(value);
-        });
-    }
+/**
+ * Annotates the key where:
+ * @param value - an example value.
+ * If the example fails to pass validation, the function will throw.
+ */
+export function Example(value : any) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.example(value);
+    });
+}
 
-    /**
-     * Marks a key as forbidden which will not allow any value except undefined. Used to explicitly forbid keys.
-     */
-    export function Forbidden() : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.forbidden();
-        });
-    }
+/**
+ * Marks a key as forbidden which will not allow any value except undefined. Used to explicitly forbid keys.
+ */
+export function Forbidden() : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.forbidden();
+    });
+}
 
-    export function Invalid(...values : any[]) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.invalid(values);
-        });
-    }
+export function Invalid(...values : any[]) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.invalid(values);
+    });
+}
 
-    export const Disallow = Invalid;
+export const Disallow = Invalid;
 
-    export const Not = Invalid;
+export const Not = Invalid;
 
-    /**
-     * Overrides the key name in error messages.
-     */
-    export function Label(name : string) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.label(name);
-        });
-    }
+/**
+ * Overrides the key name in error messages.
+ */
+export function Label(name : string) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.label(name);
+    });
+}
 
-    /**
-     * Attaches metadata to the key where:
-     * @param meta - the meta object to attach.
-     */
-    export function Meta(meta : any) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.meta(meta);
-        });
-    }
+/**
+ * Attaches metadata to the key where:
+ * @param meta - the meta object to attach.
+ */
+export function Meta(meta : any) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.meta(meta);
+    });
+}
 
-    /**
-     * Annotates the key where:
-     * @param notes - the notes string or multiple strings.
-     */
-    export function Notes(...notes : string[]) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.notes(notes);
-        });
-    }
+/**
+ * Annotates the key where:
+ * @param notes - the notes string or multiple strings.
+ */
+export function Notes(...notes : string[]) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.notes(notes);
+    });
+}
 
-    export function Optional() : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.optional();
-        });
-    }
+export function Optional() : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.optional();
+    });
+}
 
-    /**
-     * Overrides the global validate() options for the current key and any sub-key where:
-     * @param options - an object with the same optional keys as Joi.validate(value, schema, options, callback).
-     */
-    export function Options(options : ValidationOptions) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.options(options);
-        });
-    }
+/**
+ * Overrides the global validate() options for the current key and any sub-key where:
+ * @param options - an object with the same optional keys as Joi.validate(value, schema, options, callback).
+ */
+export function Options(options : ValidationOptions) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.options(options);
+    });
+}
 
-    /**
-     * Outputs the original untouched value instead of the casted value.
-     */
-    export function Raw(isRaw? : boolean) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.raw(isRaw);
-        });
-    }
+/**
+ * Outputs the original untouched value instead of the casted value.
+ */
+export function Raw(isRaw? : boolean) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.raw(isRaw);
+    });
+}
 
-    export function Required() : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.required();
-        });
-    }
+export function Required() : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.required();
+    });
+}
 
-    /**
-     * Strict mode sets the options.convert options to false which prevent type casting for the current key and any child keys.
-     * @param isStrict - whether strict mode is enabled or not. Defaults to true.
-     */
-    export function Strict(isStrict? : boolean) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.strict(isStrict);
-        });
-    }
+/**
+ * Strict mode sets the options.convert options to false which prevent type casting for the current key and any child keys.
+ * @param isStrict - whether strict mode is enabled or not. Defaults to true.
+ */
+export function Strict(isStrict? : boolean) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.strict(isStrict);
+    });
+}
 
-    /**
-     * Marks a key to be removed from a resulting object or array after validation. Used to sanitize output.
-     */
-    export function Strip() : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.strip();
-        });
-    }
+/**
+ * Marks a key to be removed from a resulting object or array after validation. Used to sanitize output.
+ */
+export function Strip() : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.strip();
+    });
+}
 
-    /**
-     * Annotates the key where:
-     * @param tags - the tag string or multiple strings.
-     */
-    export function Tags(...tags : string[]) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.tags(tags);
-        });
-    }
+/**
+ * Annotates the key where:
+ * @param tags - the tag string or multiple strings.
+ */
+export function Tags(...tags : string[]) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.tags(tags);
+    });
+}
 
-    /**
-     * Annotates the key where:
-     * @param name - the unit name of the value.
-     */
-    export function Unit(name : string) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.unit(name);
-        });
-    }
+/**
+ * Annotates the key where:
+ * @param name - the unit name of the value.
+ */
+export function Unit(name : string) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.unit(name);
+    });
+}
 
-    export function Valid(...values : any[]) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.valid(values);
-        });
-    }
+export function Valid(...values : any[]) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.valid(values);
+    });
+}
 
-    export const Only = Valid;
+export const Only = Valid;
 
-    export const Equal = Valid;
+export const Equal = Valid;
 
-    /**
-     * Converts the type into an alternatives type where the conditions are merged into the type definition.
-     */
-    export function When<T>(ref : string | Reference, options : WhenOptions<T>) : PropertyDecorator {
-        return constraintDecorator([], (schema : Schema) => {
-            return schema.when<T>(<any>ref, options);
-        });
-    }
+/**
+ * Converts the type into an alternatives type where the conditions are merged into the type definition.
+ */
+export function When<T>(ref : string | Reference, options : WhenOptions<T>) : PropertyDecorator {
+    return constraintDecorator([], (schema : Schema) => {
+        return schema.when<T>(<any>ref, options);
+    });
 }

--- a/src/constraints/array.ts
+++ b/src/constraints/array.ts
@@ -1,75 +1,73 @@
 import {ArraySchema, Schema} from "joi";
 import {typeConstraintDecorator, constraintDecorator} from "../core";
 
-export namespace ArrayConstraints {
-    export function ArraySchema() : PropertyDecorator {
-        return typeConstraintDecorator([Array], (Joi) => {
-            return Joi.array();
-        });
-    }
+export function ArraySchema() : PropertyDecorator {
+    return typeConstraintDecorator([Array], (Joi) => {
+        return Joi.array();
+    });
+}
 
-    /**
-     * List the types allowed for the array values.
-     */
-    export function Items(type : Schema, ...types : Schema[]) : PropertyDecorator {
-        types = [type].concat(types);
-        return constraintDecorator([Array], (schema : Schema) => {
-            return (schema as ArraySchema).items(types);
-        });
-    }
+/**
+ * List the types allowed for the array values.
+ */
+export function Items(type : Schema, ...types : Schema[]) : PropertyDecorator {
+    types = [type].concat(types);
+    return constraintDecorator([Array], (schema : Schema) => {
+        return (schema as ArraySchema).items(types);
+    });
+}
 
-    export function Length(limit : number) : PropertyDecorator {
-        return constraintDecorator([Array], (schema : Schema) => {
-            return (schema as ArraySchema).length(limit);
-        });
-    }
+export function Length(limit : number) : PropertyDecorator {
+    return constraintDecorator([Array], (schema : Schema) => {
+        return (schema as ArraySchema).length(limit);
+    });
+}
 
-    export function Max(limit : number) : PropertyDecorator {
-        return constraintDecorator([Array], (schema : Schema) => {
-            return (schema as ArraySchema).max(limit);
-        });
-    }
+export function Max(limit : number) : PropertyDecorator {
+    return constraintDecorator([Array], (schema : Schema) => {
+        return (schema as ArraySchema).max(limit);
+    });
+}
 
-    export function Min(limit : number) : PropertyDecorator {
-        return constraintDecorator([Array], (schema : Schema) => {
-            return (schema as ArraySchema).min(limit);
-        });
-    }
+export function Min(limit : number) : PropertyDecorator {
+    return constraintDecorator([Array], (schema : Schema) => {
+        return (schema as ArraySchema).min(limit);
+    });
+}
 
-    /**
-     * List the types in sequence order for the array values..
-     */
-    export function Ordered(...types : Schema[]) : PropertyDecorator {
-        return constraintDecorator([Array], (schema : Schema) => {
-            return (schema as ArraySchema).ordered.apply(schema, types); // hmm?
-        });
-    }
+/**
+ * List the types in sequence order for the array values..
+ */
+export function Ordered(...types : Schema[]) : PropertyDecorator {
+    return constraintDecorator([Array], (schema : Schema) => {
+        return (schema as ArraySchema).ordered.apply(schema, types); // hmm?
+    });
+}
 
-    /**
-     * Allow single values to be checked against rules as if it were provided as an array.
-     * enabled can be used with a falsy value to go back to the default behavior.
-     */
-    export function Single(enabled? : boolean | any) : PropertyDecorator {
-        return constraintDecorator([Array], (schema : Schema) => {
-            return (schema as ArraySchema).single(enabled);
-        });
-    }
+/**
+ * Allow single values to be checked against rules as if it were provided as an array.
+ * enabled can be used with a falsy value to go back to the default behavior.
+ */
+export function Single(enabled? : boolean | any) : PropertyDecorator {
+    return constraintDecorator([Array], (schema : Schema) => {
+        return (schema as ArraySchema).single(enabled);
+    });
+}
 
-    /**
-     * Allow this array to be sparse. enabled can be used with a falsy value to go back to the default behavior.
-     */
-    export function Sparse(enabled? : boolean | any) : PropertyDecorator {
-        return constraintDecorator([Array], (schema : Schema) => {
-            return (schema as ArraySchema).sparse(enabled);
-        });
-    }
+/**
+ * Allow this array to be sparse. enabled can be used with a falsy value to go back to the default behavior.
+ */
+export function Sparse(enabled? : boolean | any) : PropertyDecorator {
+    return constraintDecorator([Array], (schema : Schema) => {
+        return (schema as ArraySchema).sparse(enabled);
+    });
+}
 
-    /**
-     * Requires the array values to be unique.
-     */
-    export function Unique() : PropertyDecorator {
-        return constraintDecorator([Array], (schema : Schema) => {
-            return (schema as ArraySchema).unique();
-        });
-    }
+/**
+ * Requires the array values to be unique.
+ */
+export function Unique() : PropertyDecorator {
+    return constraintDecorator([Array], (schema : Schema) => {
+        return (schema as ArraySchema).unique();
+    });
 }

--- a/src/constraints/boolean.ts
+++ b/src/constraints/boolean.ts
@@ -1,30 +1,28 @@
 import {BooleanSchema, Schema} from "joi";
 import {constraintDecorator, typeConstraintDecorator} from "../core";
 
-export namespace BooleanConstraints {
-    export function BooleanSchema() : PropertyDecorator {
-        return typeConstraintDecorator([Boolean], (Joi) => {
-            return Joi.boolean();
-        });
-    }
+export function BooleanSchema() : PropertyDecorator {
+    return typeConstraintDecorator([Boolean], (Joi) => {
+        return Joi.boolean();
+    });
+}
 
-    export function Truthy(value : string | number, ...values : Array<string | number>) {
-        values = [value].concat(values);
-        return constraintDecorator([Boolean], (schema : Schema) => {
-            return (schema as BooleanSchema).truthy(...values);
-        });
-    }
+export function Truthy(value : string | number, ...values : Array<string | number>) {
+    values = [value].concat(values);
+    return constraintDecorator([Boolean], (schema : Schema) => {
+        return (schema as BooleanSchema).truthy(...values);
+    });
+}
 
-    export function Falsy(value : string | number, ...values : Array<string | number>) {
-        values = [value].concat(values);
-        return constraintDecorator([Boolean], (schema : Schema) => {
-            return (schema as BooleanSchema).falsy(...values);
-        });
-    }
+export function Falsy(value : string | number, ...values : Array<string | number>) {
+    values = [value].concat(values);
+    return constraintDecorator([Boolean], (schema : Schema) => {
+        return (schema as BooleanSchema).falsy(...values);
+    });
+}
 
-    export function Insensitive(enabled : boolean = true) {
-        return constraintDecorator([Boolean], (schema : Schema) => {
-            return (schema as BooleanSchema).insensitive(enabled);
-        });
-    }
+export function Insensitive(enabled : boolean = true) {
+    return constraintDecorator([Boolean], (schema : Schema) => {
+        return (schema as BooleanSchema).insensitive(enabled);
+    });
 }

--- a/src/constraints/date.ts
+++ b/src/constraints/date.ts
@@ -1,34 +1,32 @@
 import {DateSchema, Reference, Schema} from "joi";
 import {typeConstraintDecorator, constraintDecorator} from "../core";
 
-export namespace DateConstraints {
-    export function DateSchema() : PropertyDecorator {
-        return typeConstraintDecorator([Date, String], (Joi) => {
-            return Joi.date();
-        });
-    }
+export function DateSchema() : PropertyDecorator {
+    return typeConstraintDecorator([Date, String], (Joi) => {
+        return Joi.date();
+    });
+}
 
-    export function Iso() : PropertyDecorator {
-        return constraintDecorator([Date, String], (schema : Schema) => {
-            return (schema as DateSchema).iso();
-        });
-    }
+export function Iso() : PropertyDecorator {
+    return constraintDecorator([Date, String], (schema : Schema) => {
+        return (schema as DateSchema).iso();
+    });
+}
 
-    export function Max(limit : number | 'now' | string | Date | Reference) : PropertyDecorator {
-        return constraintDecorator([Date, String], (schema : Schema) => {
-            return (schema as DateSchema).max(<any>limit);
-        });
-    }
+export function Max(limit : number | 'now' | string | Date | Reference) : PropertyDecorator {
+    return constraintDecorator([Date, String], (schema : Schema) => {
+        return (schema as DateSchema).max(<any>limit);
+    });
+}
 
-    export function Min(limit : number | 'now' | string | Date | Reference) : PropertyDecorator {
-        return constraintDecorator([Date, String], (schema : Schema) => {
-            return (schema as DateSchema).min(<any>limit);
-        });
-    }
+export function Min(limit : number | 'now' | string | Date | Reference) : PropertyDecorator {
+    return constraintDecorator([Date, String], (schema : Schema) => {
+        return (schema as DateSchema).min(<any>limit);
+    });
+}
 
-    export function Timestamp(type? : 'unix' | 'javascript') : PropertyDecorator {
-        return constraintDecorator([Date, String], (schema : Schema) => {
-            return (schema as DateSchema).timestamp(type);
-        });
-    }
+export function Timestamp(type? : 'unix' | 'javascript') : PropertyDecorator {
+    return constraintDecorator([Date, String], (schema : Schema) => {
+        return (schema as DateSchema).timestamp(type);
+    });
 }

--- a/src/constraints/func.ts
+++ b/src/constraints/func.ts
@@ -1,28 +1,26 @@
 import {typeConstraintDecorator, constraintDecorator} from "../core";
 import {FunctionSchema, Schema} from "joi";
 
-export namespace FunctionConstraints {
-    export function Arity(n : number) : PropertyDecorator {
-        return constraintDecorator([Function], (schema : Schema) => {
-            return (schema as FunctionSchema).arity(n);
-        });
-    }
+export function Arity(n : number) : PropertyDecorator {
+    return constraintDecorator([Function], (schema : Schema) => {
+        return (schema as FunctionSchema).arity(n);
+    });
+}
 
-    export function FuncSchema() : PropertyDecorator {
-        return typeConstraintDecorator([Function], (Joi) => {
-            return Joi.func();
-        });
-    }
+export function FuncSchema() : PropertyDecorator {
+    return typeConstraintDecorator([Function], (Joi) => {
+        return Joi.func();
+    });
+}
 
-    export function MaxArity(n : number) : PropertyDecorator {
-        return constraintDecorator([Function], (schema : Schema) => {
-            return (schema as FunctionSchema).maxArity(n);
-        });
-    }
+export function MaxArity(n : number) : PropertyDecorator {
+    return constraintDecorator([Function], (schema : Schema) => {
+        return (schema as FunctionSchema).maxArity(n);
+    });
+}
 
-    export function MinArity(n : number) : PropertyDecorator {
-        return constraintDecorator([Function], (schema : Schema) => {
-            return (schema as FunctionSchema).minArity(n);
-        });
-    }
+export function MinArity(n : number) : PropertyDecorator {
+    return constraintDecorator([Function], (schema : Schema) => {
+        return (schema as FunctionSchema).minArity(n);
+    });
 }

--- a/src/constraints/number.ts
+++ b/src/constraints/number.ts
@@ -1,64 +1,62 @@
 import {Reference, NumberSchema, Schema} from "joi";
 import {constraintDecorator, typeConstraintDecorator} from "../core";
 
-export namespace NumberConstraints {
-    export function Greater(limit : number | Reference) : PropertyDecorator {
-        return constraintDecorator([Number], (schema : Schema) => {
-            return (schema as NumberSchema).greater(<any>limit);
-        });
-    }
+export function Greater(limit : number | Reference) : PropertyDecorator {
+    return constraintDecorator([Number], (schema : Schema) => {
+        return (schema as NumberSchema).greater(<any>limit);
+    });
+}
 
-    export function Integer() : PropertyDecorator {
-        return constraintDecorator([Number], (schema : Schema) => {
-            return (schema as NumberSchema).integer();
-        });
-    }
+export function Integer() : PropertyDecorator {
+    return constraintDecorator([Number], (schema : Schema) => {
+        return (schema as NumberSchema).integer();
+    });
+}
 
-    export function Less(limit : number | Reference) : PropertyDecorator {
-        return constraintDecorator([Number], (schema : Schema) => {
-            return (schema as NumberSchema).less(<any>limit);
-        });
-    }
+export function Less(limit : number | Reference) : PropertyDecorator {
+    return constraintDecorator([Number], (schema : Schema) => {
+        return (schema as NumberSchema).less(<any>limit);
+    });
+}
 
-    export function Max(limit : number | Reference) : PropertyDecorator {
-        return constraintDecorator([Number], (schema : Schema) => {
-            return (schema as NumberSchema).max(<any>limit);
-        });
-    }
+export function Max(limit : number | Reference) : PropertyDecorator {
+    return constraintDecorator([Number], (schema : Schema) => {
+        return (schema as NumberSchema).max(<any>limit);
+    });
+}
 
-    export function Min(limit : number | Reference) : PropertyDecorator {
-        return constraintDecorator([Number], (schema : Schema) => {
-            return (schema as NumberSchema).min(<any>limit);
-        });
-    }
+export function Min(limit : number | Reference) : PropertyDecorator {
+    return constraintDecorator([Number], (schema : Schema) => {
+        return (schema as NumberSchema).min(<any>limit);
+    });
+}
 
-    export function Multiple(base : number) : PropertyDecorator {
-        return constraintDecorator([Number], (schema : Schema) => {
-            return (schema as NumberSchema).multiple(base);
-        });
-    }
+export function Multiple(base : number) : PropertyDecorator {
+    return constraintDecorator([Number], (schema : Schema) => {
+        return (schema as NumberSchema).multiple(base);
+    });
+}
 
-    export function Negative() : PropertyDecorator {
-        return constraintDecorator([Number], (schema : Schema) => {
-            return (schema as NumberSchema).negative();
-        });
-    }
+export function Negative() : PropertyDecorator {
+    return constraintDecorator([Number], (schema : Schema) => {
+        return (schema as NumberSchema).negative();
+    });
+}
 
-    export function NumberSchema() : PropertyDecorator {
-        return typeConstraintDecorator([Number], (Joi) => {
-            return Joi.number();
-        });
-    }
+export function NumberSchema() : PropertyDecorator {
+    return typeConstraintDecorator([Number], (Joi) => {
+        return Joi.number();
+    });
+}
 
-    export function Positive() : PropertyDecorator {
-        return constraintDecorator([Number], (schema : Schema) => {
-            return (schema as NumberSchema).positive();
-        });
-    }
+export function Positive() : PropertyDecorator {
+    return constraintDecorator([Number], (schema : Schema) => {
+        return (schema as NumberSchema).positive();
+    });
+}
 
-    export function Precision(limit : number) : PropertyDecorator {
-        return constraintDecorator([Number], (schema : Schema) => {
-            return (schema as NumberSchema).precision(limit);
-        });
-    }
+export function Precision(limit : number) : PropertyDecorator {
+    return constraintDecorator([Number], (schema : Schema) => {
+        return (schema as NumberSchema).precision(limit);
+    });
 }

--- a/src/constraints/object.ts
+++ b/src/constraints/object.ts
@@ -1,118 +1,116 @@
 import {ObjectSchema, Reference, RenameOptions, Schema, SchemaMap} from "joi";
 import {constraintDecorator, constraintDecoratorWithPeers, typeConstraintDecorator} from "../core";
 
-export namespace ObjectConstraints {
-    export function And<TClass>(peer : keyof TClass, ...peers : (keyof TClass)[]) : PropertyDecorator {
-        peers = [peer].concat(peers);
-        return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
-            return (schema as ObjectSchema).and(peers as string[]);
-        });
-    }
+export function And<TClass>(peer : keyof TClass, ...peers : (keyof TClass)[]) : PropertyDecorator {
+    peers = [peer].concat(peers);
+    return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
+        return (schema as ObjectSchema).and(peers as string[]);
+    });
+}
 
-    export function Assert(ref : string | Reference, schema : Schema, message? : string) : PropertyDecorator {
-        return constraintDecorator([Object], (schemaToUpdate : Schema) => {
-            return (schemaToUpdate as ObjectSchema).assert(<any>ref, schema, message);
-        });
-    }
+export function Assert(ref : string | Reference, schema : Schema, message? : string) : PropertyDecorator {
+    return constraintDecorator([Object], (schemaToUpdate : Schema) => {
+        return (schemaToUpdate as ObjectSchema).assert(<any>ref, schema, message);
+    });
+}
 
-    export type KeysSchemaMap<TClass> = { [P in keyof TClass]: Schema | SchemaMap | (Schema | SchemaMap)[] };
+export type KeysSchemaMap<TClass> = { [P in keyof TClass]: Schema | SchemaMap | (Schema | SchemaMap)[] };
 
-    export function Keys<TClass>(schema? : KeysSchemaMap<TClass>) : PropertyDecorator {
-        return constraintDecorator([Object], (schemaToUpdate : Schema) => {
-            return (schemaToUpdate as ObjectSchema).keys(schema);
-        });
-    }
+export function Keys<TClass>(schema? : KeysSchemaMap<TClass>) : PropertyDecorator {
+    return constraintDecorator([Object], (schemaToUpdate : Schema) => {
+        return (schemaToUpdate as ObjectSchema).keys(schema);
+    });
+}
 
-    export function Length(limit : number) : PropertyDecorator {
-        return constraintDecorator([Object], (schema : Schema) => {
-            return (schema as ObjectSchema).length(limit);
-        });
-    }
+export function Length(limit : number) : PropertyDecorator {
+    return constraintDecorator([Object], (schema : Schema) => {
+        return (schema as ObjectSchema).length(limit);
+    });
+}
 
-    export function Max(limit : number) : PropertyDecorator {
-        return constraintDecorator([Object], (schema : Schema) => {
-            return (schema as ObjectSchema).max(limit);
-        });
-    }
+export function Max(limit : number) : PropertyDecorator {
+    return constraintDecorator([Object], (schema : Schema) => {
+        return (schema as ObjectSchema).max(limit);
+    });
+}
 
-    export function Min(limit : number) : PropertyDecorator {
-        return constraintDecorator([Object], (schema : Schema) => {
-            return (schema as ObjectSchema).min(limit);
-        });
-    }
+export function Min(limit : number) : PropertyDecorator {
+    return constraintDecorator([Object], (schema : Schema) => {
+        return (schema as ObjectSchema).min(limit);
+    });
+}
 
-    export function Nand<TClass>(peer : keyof TClass, ...peers : (keyof TClass)[]) : PropertyDecorator {
-        peers = [peer].concat(peers);
-        return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
-            return (schema as ObjectSchema).nand(peers as string[]);
-        });
-    }
+export function Nand<TClass>(peer : keyof TClass, ...peers : (keyof TClass)[]) : PropertyDecorator {
+    peers = [peer].concat(peers);
+    return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
+        return (schema as ObjectSchema).nand(peers as string[]);
+    });
+}
 
-    export function ObjectSchema(schema? : SchemaMap) : PropertyDecorator {
-        return typeConstraintDecorator([Object], (Joi) => {
-            return Joi.object(schema);
-        });
-    }
+export function ObjectSchema(schema? : SchemaMap) : PropertyDecorator {
+    return typeConstraintDecorator([Object], (Joi) => {
+        return Joi.object(schema);
+    });
+}
 
-    export function OptionalKeys<TClass>(...children : (keyof TClass)[]) : PropertyDecorator {
-        return constraintDecorator([Object], (schema : Schema) => {
-            return (schema as ObjectSchema).optionalKeys(children as string[]);
-        });
-    }
+export function OptionalKeys<TClass>(...children : (keyof TClass)[]) : PropertyDecorator {
+    return constraintDecorator([Object], (schema : Schema) => {
+        return (schema as ObjectSchema).optionalKeys(children as string[]);
+    });
+}
 
-    export function Or<TClass>(peer : keyof TClass, ...peers : (keyof TClass)[]) : PropertyDecorator {
-        peers = [peer].concat(peers);
-        return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
-            return (schema as ObjectSchema).or(peers as string[]);
-        });
-    }
+export function Or<TClass>(peer : keyof TClass, ...peers : (keyof TClass)[]) : PropertyDecorator {
+    peers = [peer].concat(peers);
+    return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
+        return (schema as ObjectSchema).or(peers as string[]);
+    });
+}
 
-    export function Pattern(regex : RegExp, schema : Schema) : PropertyDecorator {
-        return constraintDecorator([Object], (objSchema : Schema) => {
-            return (objSchema as ObjectSchema).pattern(regex, schema);
-        });
-    }
+export function Pattern(regex : RegExp, schema : Schema) : PropertyDecorator {
+    return constraintDecorator([Object], (objSchema : Schema) => {
+        return (objSchema as ObjectSchema).pattern(regex, schema);
+    });
+}
 
-    export function Rename(from : string, to : string, options? : RenameOptions) : PropertyDecorator {
-        return constraintDecorator([Object], (schema : Schema) => {
-            return (schema as ObjectSchema).rename(from, to, options);
-        });
-    }
+export function Rename(from : string, to : string, options? : RenameOptions) : PropertyDecorator {
+    return constraintDecorator([Object], (schema : Schema) => {
+        return (schema as ObjectSchema).rename(from, to, options);
+    });
+}
 
-    export function RequiredKeys<TClass>(...children : (keyof TClass)[]) : PropertyDecorator {
-        return constraintDecorator([Object], (schema : Schema) => {
-            return (schema as ObjectSchema).requiredKeys(children as string[]);
-        });
-    }
+export function RequiredKeys<TClass>(...children : (keyof TClass)[]) : PropertyDecorator {
+    return constraintDecorator([Object], (schema : Schema) => {
+        return (schema as ObjectSchema).requiredKeys(children as string[]);
+    });
+}
 
-    export function Type(constructor : Function, name? : string) : PropertyDecorator {
-        return constraintDecorator([Object], (schema : Schema) => {
-            return (schema as ObjectSchema).type(constructor, name);
-        });
-    }
+export function Type(constructor : Function, name? : string) : PropertyDecorator {
+    return constraintDecorator([Object], (schema : Schema) => {
+        return (schema as ObjectSchema).type(constructor, name);
+    });
+}
 
-    export function Unknown(allow? : boolean) : PropertyDecorator {
-        return constraintDecorator([Object], (schema : Schema) => {
-            return (schema as ObjectSchema).unknown(allow);
-        });
-    }
+export function Unknown(allow? : boolean) : PropertyDecorator {
+    return constraintDecorator([Object], (schema : Schema) => {
+        return (schema as ObjectSchema).unknown(allow);
+    });
+}
 
-    export function With<TClass>(key : keyof TClass, peers : (keyof TClass)[]) : PropertyDecorator {
-        return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
-            return (schema as ObjectSchema).with(key as string, peers as string[]);
-        });
-    }
+export function With<TClass>(key : keyof TClass, peers : (keyof TClass)[]) : PropertyDecorator {
+    return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
+        return (schema as ObjectSchema).with(key as string, peers as string[]);
+    });
+}
 
-    export function Without<TClass>(key : keyof TClass, peers : (keyof TClass)[]) : PropertyDecorator {
-        return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
-            return (schema as ObjectSchema).without(key as string, peers as string[]);
-        });
-    }
+export function Without<TClass>(key : keyof TClass, peers : (keyof TClass)[]) : PropertyDecorator {
+    return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
+        return (schema as ObjectSchema).without(key as string, peers as string[]);
+    });
+}
 
-    export function Xor<TClass>(peer : keyof TClass, ...peers : (keyof TClass)[]) : PropertyDecorator {
-        peers = [peer].concat(peers);
-        return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
-            return (schema as ObjectSchema).xor(peers as string[]);
-        });
-    }
+export function Xor<TClass>(peer : keyof TClass, ...peers : (keyof TClass)[]) : PropertyDecorator {
+    peers = [peer].concat(peers);
+    return constraintDecoratorWithPeers([Object], peers, (schema : Schema) => {
+        return (schema as ObjectSchema).xor(peers as string[]);
+    });
 }

--- a/src/constraints/string.ts
+++ b/src/constraints/string.ts
@@ -1,121 +1,119 @@
 import {EmailOptions, IpOptions, Reference, StringSchema, UriOptions, Schema} from "joi";
 import {constraintDecorator, typeConstraintDecorator} from "../core";
 
-export namespace StringConstraints {
-    export function Alphanum() : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).alphanum();
-        });
-    }
+export function Alphanum() : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).alphanum();
+    });
+}
 
-    export function CreditCard() : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).creditCard();
-        });
-    }
+export function CreditCard() : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).creditCard();
+    });
+}
 
-    export function Email(options? : EmailOptions) : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).email(options);
-        });
-    }
+export function Email(options? : EmailOptions) : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).email(options);
+    });
+}
 
-    export function Guid() : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).guid();
-        });
-    }
+export function Guid() : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).guid();
+    });
+}
 
-    export function Hex() : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).hex();
-        });
-    }
+export function Hex() : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).hex();
+    });
+}
 
-    export function Hostname() : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).hostname();
-        });
-    }
+export function Hostname() : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).hostname();
+    });
+}
 
-    export function Ip(options? : IpOptions) : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).ip(options);
-        });
-    }
+export function Ip(options? : IpOptions) : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).ip(options);
+    });
+}
 
-    export function IsoDate() : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).isoDate();
-        });
-    }
+export function IsoDate() : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).isoDate();
+    });
+}
 
-    export function Length(limit : number | Reference, encoding? : string) : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).length(<any>limit, encoding);
-        });
-    }
+export function Length(limit : number | Reference, encoding? : string) : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).length(<any>limit, encoding);
+    });
+}
 
-    export function Lowercase() : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).lowercase();
-        });
-    }
+export function Lowercase() : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).lowercase();
+    });
+}
 
-    export function Max(limit : number | Reference, encoding? : string) : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).max(<any>limit, encoding);
-        });
-    }
+export function Max(limit : number | Reference, encoding? : string) : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).max(<any>limit, encoding);
+    });
+}
 
-    export function Min(limit : number | Reference, encoding? : string) : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).min(<any>limit, encoding);
-        });
-    }
+export function Min(limit : number | Reference, encoding? : string) : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).min(<any>limit, encoding);
+    });
+}
 
-    export function Regex(pattern : RegExp, name? : string) : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).regex(pattern, name);
-        });
-    }
+export function Regex(pattern : RegExp, name? : string) : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).regex(pattern, name);
+    });
+}
 
-    export const Pattern = Regex;
+export const Pattern = Regex;
 
-    export function Replace(pattern : RegExp, replacement : string) : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).replace(pattern, replacement);
-        });
-    }
+export function Replace(pattern : RegExp, replacement : string) : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).replace(pattern, replacement);
+    });
+}
 
-    export function StringSchema() : PropertyDecorator {
-        return typeConstraintDecorator([String], (Joi) => {
-            return <Schema> Joi.string();
-        });
-    }
+export function StringSchema() : PropertyDecorator {
+    return typeConstraintDecorator([String], (Joi) => {
+        return <Schema> Joi.string();
+    });
+}
 
-    export function Token() : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).token();
-        });
-    }
+export function Token() : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).token();
+    });
+}
 
-    export function Trim() : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).trim();
-        });
-    }
+export function Trim() : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).trim();
+    });
+}
 
-    export function Uppercase() : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).uppercase();
-        });
-    }
+export function Uppercase() : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).uppercase();
+    });
+}
 
 // TODO: update Joi UriOptions to support "allowRelative" option.
-    export function Uri(options? : UriOptions) : PropertyDecorator {
-        return constraintDecorator([String], (schema : Schema) => {
-            return (schema as StringSchema).uri(options);
-        });
-    }
+export function Uri(options? : UriOptions) : PropertyDecorator {
+    return constraintDecorator([String], (schema : Schema) => {
+        return (schema as StringSchema).uri(options);
+    });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,11 +5,22 @@ export {Nested, NestedArray} from "./Nested";
 export {Validate} from "./Validate";
 export {Validator} from "./Validator";
 
-export {AnyConstraints} from "./constraints/any";
-export {ArrayConstraints} from "./constraints/array";
-export {BooleanConstraints} from "./constraints/boolean";
-export {DateConstraints} from "./constraints/date";
-export {FunctionConstraints} from "./constraints/func";
-export {NumberConstraints} from "./constraints/number";
-export {ObjectConstraints} from "./constraints/object";
-export {StringConstraints} from "./constraints/string";
+import * as AnyConstraints from "./constraints/any";
+import * as ArrayConstraints from "./constraints/any";
+import * as BooleanConstraints from "./constraints/boolean";
+import * as DateConstraints from "./constraints/date";
+import * as FunctionConstraints from "./constraints/func";
+import * as NumberConstraints from "./constraints/number";
+import * as ObjectConstraints from "./constraints/object";
+import * as StringConstraints from "./constraints/string";
+
+export {
+    AnyConstraints,
+    ArrayConstraints,
+    BooleanConstraints,
+    DateConstraints,
+    FunctionConstraints,
+    NumberConstraints,
+    ObjectConstraints,
+    StringConstraints
+};

--- a/test/unit/Validate.ts
+++ b/test/unit/Validate.ts
@@ -5,10 +5,9 @@ import {Validate} from "../../src/Validate";
 import {MultipleValidationError} from "../../src/MultipleValidationError";
 import {registerJoi} from "../../src/core";
 import * as Joi from "joi";
-import {StringConstraints} from "../../src/constraints/string";
+import {Length} from "../../src/constraints/string";
 import AssertStatic = Chai.AssertStatic;
 const assert : AssertStatic = chai.assert;
-import Length = StringConstraints.Length;
 
 registerJoi(Joi);
 

--- a/test/unit/constraints/boolean.ts
+++ b/test/unit/constraints/boolean.ts
@@ -3,12 +3,8 @@ import * as chai from "chai";
 import {ConstraintDefinitionError, registerJoi, WORKING_SCHEMA_KEY} from "../../../src/core";
 import * as Joi from "joi";
 import {testConstraint} from "../testUtil";
-import {BooleanConstraints} from "../../../src/constraints/boolean";
+import {BooleanSchema, Truthy, Falsy, Insensitive} from "../../../src/constraints/boolean";
 import AssertStatic = Chai.AssertStatic;
-import BooleanSchema = BooleanConstraints.BooleanSchema;
-import Truthy = BooleanConstraints.Truthy;
-import Falsy = BooleanConstraints.Falsy;
-import Insensitive = BooleanConstraints.Insensitive;
 const assert : AssertStatic = chai.assert;
 
 

--- a/test/unit/constraints/date.ts
+++ b/test/unit/constraints/date.ts
@@ -3,10 +3,8 @@ import * as chai from "chai";
 import {ConstraintDefinitionError, registerJoi, WORKING_SCHEMA_KEY} from "../../../src/core";
 import * as Joi from "joi";
 import {testConstraint} from "../testUtil";
-import {DateConstraints} from "../../../src/constraints/date";
+import {DateSchema, Iso} from "../../../src/constraints/date";
 import AssertStatic = Chai.AssertStatic;
-import DateSchema = DateConstraints.DateSchema;
-import Iso = DateConstraints.Iso;
 const assert : AssertStatic = chai.assert;
 
 registerJoi(Joi);

--- a/test/unit/constraints/string.ts
+++ b/test/unit/constraints/string.ts
@@ -1,30 +1,14 @@
 import "../metadataShim";
 import * as chai from "chai";
 import {SCHEMA_KEY, ConstraintDefinitionError, registerJoi, WORKING_SCHEMA_KEY} from "../../../src/core";
-import {StringConstraints} from "../../../src/constraints/string";
+import {
+    StringSchema, Length, Alphanum, CreditCard, Email, Guid, Hex, Hostname, Ip,
+    IsoDate, Lowercase, Max, Min, Regex, Replace, Token, Trim, Uppercase, Uri
+} from "../../../src/constraints/string";
 import * as Joi from "joi";
 import {Validator} from "../../../src/Validator";
 import {isValid, isInvalid, testConstraint, testConversion} from "../testUtil";
 import AssertStatic = Chai.AssertStatic;
-import StringSchema = StringConstraints.StringSchema;
-import Length = StringConstraints.Length;
-import Alphanum = StringConstraints.Alphanum;
-import CreditCard = StringConstraints.CreditCard;
-import Email = StringConstraints.Email;
-import Guid = StringConstraints.Guid;
-import Hex = StringConstraints.Hex;
-import Hostname = StringConstraints.Hostname;
-import Ip = StringConstraints.Ip;
-import IsoDate = StringConstraints.IsoDate;
-import Lowercase = StringConstraints.Lowercase;
-import Max = StringConstraints.Max;
-import Min = StringConstraints.Min;
-import Regex = StringConstraints.Regex;
-import Replace = StringConstraints.Replace;
-import Token = StringConstraints.Token;
-import Trim = StringConstraints.Trim;
-import Uppercase = StringConstraints.Uppercase;
-import Uri = StringConstraints.Uri;
 const assert : AssertStatic = chai.assert;
 
 registerJoi(Joi);

--- a/test/unit/examples.ts
+++ b/test/unit/examples.ts
@@ -4,9 +4,7 @@ import {isValid, isInvalid} from "./testUtil";
 import {registerJoi} from "../../src/core";
 import * as Joi from "joi";
 import {Nested} from "../../src/Nested";
-import {StringConstraints} from "../../src/constraints/string";
-import Length = StringConstraints.Length;
-import StringSchema = StringConstraints.StringSchema;
+import {Length, StringSchema} from "../../src/constraints/string";
 
 registerJoi(Joi);
 

--- a/test/unit/gotchas.ts
+++ b/test/unit/gotchas.ts
@@ -1,15 +1,10 @@
 import {isValid} from "./testUtil";
 import {Validator} from "../../src/Validator";
-import {NumberConstraints} from "../../src/constraints/number";
-import NumberSchema = NumberConstraints.NumberSchema;
-import Min = NumberConstraints.Min;
+import {NumberSchema, Min} from "../../src/constraints/number";
 import { assert } from "chai";
 import {ConstraintDefinitionError, Joi} from "../../src/core";
-import {AnyConstraints} from "../../src/constraints/any";
-import Optional = AnyConstraints.Optional;
-import {ObjectConstraints} from "../../src/constraints/object";
-import Keys = ObjectConstraints.Keys;
-import ObjectSchema = ObjectConstraints.ObjectSchema;
+import {Optional} from "../../src/constraints/any";
+import {Keys, ObjectSchema} from "../../src/constraints/object";
 
 describe(`Gotchas`, function () {
     describe(`object types`, function () {

--- a/test/unit/inheritance.ts
+++ b/test/unit/inheritance.ts
@@ -1,8 +1,7 @@
-import {NumberConstraints} from "../../src/constraints/number";
+import {Min} from "../../src/constraints/number";
 import {isInvalid, isValid} from "./testUtil";
 import {Validator} from "../../src/Validator";
 import {assert} from "chai";
-import Min = NumberConstraints.Min;
 import {getMergedWorkingSchemas, getWorkingSchema} from "../../src/core";
 
 describe(`Inheritance`, function () {

--- a/test/unit/messages.ts
+++ b/test/unit/messages.ts
@@ -3,10 +3,9 @@ import * as chai from "chai";
 import {Validator} from "../../src/Validator";
 import {registerJoi} from "../../src/core";
 import * as Joi from "joi";
-import {StringConstraints} from "../../src/constraints/string";
+import {Length} from "../../src/constraints/string";
 import AssertStatic = Chai.AssertStatic;
 const assert : AssertStatic = chai.assert;
-import Length = StringConstraints.Length;
 import {isValidationFail} from "../../src/ValidationResult";
 
 registerJoi(Joi);

--- a/test/unit/nested.ts
+++ b/test/unit/nested.ts
@@ -3,13 +3,11 @@ import * as chai from "chai";
 import {Validator} from "../../src/Validator";
 import {registerJoi} from "../../src/core";
 import * as Joi from "joi";
-import {StringConstraints} from "../../src/constraints/string";
+import {Length} from "../../src/constraints/string";
 import {Nested, NestedArray} from "../../src/Nested";
-import {AnyConstraints} from "../../src/constraints/any";
+import {Required} from "../../src/constraints/any";
 import AssertStatic = Chai.AssertStatic;
 const assert : AssertStatic = chai.assert;
-const Length = StringConstraints.Length;
-const Required = AnyConstraints.Required;
 
 registerJoi(Joi);
 


### PR DESCRIPTION
Closes #2 by removing constraint namespaces and exporting decorators from constraint modules directly.

Library consumer can now import the decorator(s) they need like so:

```typescript
import { Optional } from 'tsdv-joi/dist/contraints/any';
```

Or still grab all decorators grouped by type:

```typescript
import { AnyConstraints } from 'tsdv-joi';
```

Note this includes breaking changes for consumers trying to import constraint namespaces directly from the individual constraint modules so they will need to be updated to either import the namespaces from the root module (`tsdv-joi`) or just import the decorators they need from the specific constraint module. I've left bumping the version for you.

Also sorry for all the whitespace noise, it's mostly from outdenting after removing namespaces.