### PR TITLE
Fix typo on import/export of array contraints

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ export {Validate} from "./Validate";
 export {Validator} from "./Validator";
 
 import * as AnyConstraints from "./constraints/any";
-import * as ArrayConstraints from "./constraints/any";
+import * as ArrayConstraints from "./constraints/array";
 import * as BooleanConstraints from "./constraints/boolean";
 import * as DateConstraints from "./constraints/date";
 import * as FunctionConstraints from "./constraints/func";


### PR DESCRIPTION
`ArrayConstraints` aren't exported due to typo in `src/main.ts`