### PR TITLE
Feature: Label provider function

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -13,6 +13,10 @@ export type LabelProvider = ((propertyKey: string | Symbol, target: object) => s
 
 let globalLabelProvider: LabelProvider | undefined | null = undefined;
 
+/**
+ * Registers a callback which will be used to generate labels for all decorated properties.
+ * @param labelProvider Function which returns the label to use for a given property key and class.
+ */
 export function registerLabelProvider(labelProvider: LabelProvider | undefined | null) {
     globalLabelProvider = labelProvider;
 }

--- a/test/unit/core.test.ts
+++ b/test/unit/core.test.ts
@@ -1,5 +1,18 @@
+import './metadataShim';
 import { Schema } from 'joi';
-import { ensureSchemaNotAlreadyDefined, ConstraintDefinitionError } from '../../src/core';
+import { Validator } from '../../src/Validator';
+import {
+    ensureSchemaNotAlreadyDefined,
+    ConstraintDefinitionError,
+    registerJoi,
+    registerLabelProvider,
+    LabelProvider,
+} from '../../src/core';
+import * as Joi from 'joi';
+import { StringSchema, Email } from '../../src/constraints/string';
+import { Required, Label } from '../../src/constraints/any';
+
+registerJoi(Joi);
 
 describe('ensureSchemaNotAlreadyDefined', () => {
     it('should throw an error if the schema is defined', () => {
@@ -11,5 +24,58 @@ describe('ensureSchemaNotAlreadyDefined', () => {
     it('should not throw an error if the schema is not defined', () => {
         const func = () => ensureSchemaNotAlreadyDefined(undefined, 'emailAddress');
         expect(func).not.toThrow();
+    });
+});
+
+describe('registerLabelProvider', () => {
+    let labelProvider: LabelProvider;
+
+    const getLoginFormClass = () => {
+        class LoginForm {
+            @Required()
+            @Email()
+            emailAddress?: string;
+
+            @Required()
+            @StringSchema()
+            password?: string;
+
+            @Required()
+            @Label("Don't you forget about me")
+            rememberMe?: boolean;
+        }
+        return LoginForm;
+    };
+
+    describe('when a label transform has been supplied', () => {
+        beforeEach(() => {
+            labelProvider = jest.fn().mockImplementation((propertyKey) => `${propertyKey}`.toUpperCase());
+            registerLabelProvider(labelProvider);
+        });
+
+        afterEach(() => {
+            registerLabelProvider(undefined);
+        });
+
+        it('should use the provided label provider when one supplied', () => {
+            const validator = new Validator();
+            const result = validator.validateAsClass({}, getLoginFormClass(), { abortEarly: false });
+            expect(result).toHaveProperty(['error', 'details', 0, 'context', 'key'], 'EMAILADDRESS');
+            expect(result).toHaveProperty(['error', 'details', 1, 'context', 'key'], 'PASSWORD');
+        });
+
+        it('should use labels provided by a Label decorators', () => {
+            const validator = new Validator();
+            const result = validator.validateAsClass({}, getLoginFormClass(), { abortEarly: false });
+            expect(result).toHaveProperty(['error', 'details', 2, 'context', 'key'], "Don't you forget about me");
+        });
+    });
+
+    it('should not use a label provider when none supplied', () => {
+        const validator = new Validator();
+        const result = validator.validateAsClass({}, getLoginFormClass(), { abortEarly: false });
+        expect(result).toHaveProperty(['error', 'details', 0, 'context', 'key'], 'emailAddress');
+        expect(result).toHaveProperty(['error', 'details', 1, 'context', 'key'], 'password');
+        expect(result).toHaveProperty(['error', 'details', 2, 'context', 'key'], "Don't you forget about me");
     });
 });


### PR DESCRIPTION
# Summary
- Adds new function `registerLabelTransformer` which accepts a function that accepts a property key and class and returns a user friendly label for that property.
- Add `.vscode` directory to git ignore
- Renames `test/unit/constraints/any.ts` to `test/unit/constraints/any.test.ts` so it gets picked up by jest
- Removes nested `it` calls from `any.test.ts`

# Motivation
Joi's error messages are mostly user friendly except for the fact that they are based on property keys. A consumer can specify user friendly labels for properties via the `Label` decorator which is good. However if most of the time the label you want is simply the property key as title or sentence case, specifying a label decorator on every property isn't very DRY (wet?) and doesn't make for a great developer experience. Having the ability to specify a label transform function once at app startup spares the developer from having to specify labels for every field.