### PR TITLE
Add fluent api to Items decorator

### DIFF
--- a/src/constraints/array.ts
+++ b/src/constraints/array.ts
@@ -1,10 +1,11 @@
-import { ArraySchema, Schema } from 'joi';
+import * as JoiModule from 'joi';
 import { constraintDecorator, typeConstraintDecorator, TypedPropertyDecorator } from '../core';
+import { Joi } from '../core';
 
 type AllowedPropertyTypes = Array<unknown>;
 
 export function ArraySchema(
-    schemaBuilder?: (schema: ArraySchema) => ArraySchema,
+    schemaBuilder?: (schema: JoiModule.ArraySchema) => JoiModule.ArraySchema,
 ): TypedPropertyDecorator<AllowedPropertyTypes> {
     return typeConstraintDecorator<AllowedPropertyTypes>((Joi) => {
         let schema = Joi.array();
@@ -15,40 +16,61 @@ export function ArraySchema(
     });
 }
 
+export function Items(
+    type: JoiModule.Schema,
+    // tslint:disable-next-line: trailing-comma
+    ...types: JoiModule.Schema[]
+): TypedPropertyDecorator<AllowedPropertyTypes>;
+
+export function Items(
+    itemsSchemaBuilder: (joi: typeof JoiModule) => JoiModule.Schema | JoiModule.Schema[],
+): TypedPropertyDecorator<AllowedPropertyTypes>;
+
 /**
  * List the types allowed for the array values.
  */
-export function Items(type: Schema, ...types: Schema[]): TypedPropertyDecorator<AllowedPropertyTypes> {
-    types = [type].concat(types);
-    return constraintDecorator<AllowedPropertyTypes>((schema: Schema) => {
-        return (schema as ArraySchema).items(types);
+export function Items(...args: any[]): TypedPropertyDecorator<AllowedPropertyTypes> {
+    const [firstArg] = args;
+
+    const itemSchemas: JoiModule.Schema[] = [];
+
+    if (args.length === 1 && typeof firstArg === 'function') {
+        const itemSchemaBuilder = firstArg as (joi: typeof JoiModule) => JoiModule.Schema | JoiModule.Schema[];
+        const result = itemSchemaBuilder(Joi);
+        itemSchemas.push(...result instanceof Array ? result : [result]);
+    } else {
+        itemSchemas.push(...args);
+    }
+
+    return constraintDecorator<AllowedPropertyTypes>((schema: JoiModule.Schema) => {
+        return (schema as JoiModule.ArraySchema).items(itemSchemas);
     });
 }
 
 export function Length(limit: number): TypedPropertyDecorator<AllowedPropertyTypes> {
-    return constraintDecorator<AllowedPropertyTypes>((schema: Schema) => {
-        return (schema as ArraySchema).length(limit);
+    return constraintDecorator<AllowedPropertyTypes>((schema: JoiModule.Schema) => {
+        return (schema as JoiModule.ArraySchema).length(limit);
     });
 }
 
 export function Max(limit: number): TypedPropertyDecorator<AllowedPropertyTypes> {
-    return constraintDecorator<AllowedPropertyTypes>((schema: Schema) => {
-        return (schema as ArraySchema).max(limit);
+    return constraintDecorator<AllowedPropertyTypes>((schema: JoiModule.Schema) => {
+        return (schema as JoiModule.ArraySchema).max(limit);
     });
 }
 
 export function Min(limit: number): TypedPropertyDecorator<AllowedPropertyTypes> {
-    return constraintDecorator<AllowedPropertyTypes>((schema: Schema) => {
-        return (schema as ArraySchema).min(limit);
+    return constraintDecorator<AllowedPropertyTypes>((schema: JoiModule.Schema) => {
+        return (schema as JoiModule.ArraySchema).min(limit);
     });
 }
 
 /**
  * List the types in sequence order for the array values..
  */
-export function Ordered(...types: Schema[]): TypedPropertyDecorator<AllowedPropertyTypes> {
-    return constraintDecorator<AllowedPropertyTypes>((schema: Schema) => {
-        return (schema as ArraySchema).ordered(types);
+export function Ordered(...types: JoiModule.Schema[]): TypedPropertyDecorator<AllowedPropertyTypes> {
+    return constraintDecorator<AllowedPropertyTypes>((schema: JoiModule.Schema) => {
+        return (schema as JoiModule.ArraySchema).ordered(types);
     });
 }
 
@@ -57,8 +79,8 @@ export function Ordered(...types: Schema[]): TypedPropertyDecorator<AllowedPrope
  * enabled can be used with a falsy value to go back to the default behavior.
  */
 export function Single(enabled?: boolean | any): TypedPropertyDecorator<AllowedPropertyTypes> {
-    return constraintDecorator<AllowedPropertyTypes>((schema: Schema) => {
-        return (schema as ArraySchema).single(enabled);
+    return constraintDecorator<AllowedPropertyTypes>((schema: JoiModule.Schema) => {
+        return (schema as JoiModule.ArraySchema).single(enabled);
     });
 }
 
@@ -66,8 +88,8 @@ export function Single(enabled?: boolean | any): TypedPropertyDecorator<AllowedP
  * Allow this array to be sparse. enabled can be used with a falsy value to go back to the default behavior.
  */
 export function Sparse(enabled?: boolean | any): TypedPropertyDecorator<AllowedPropertyTypes> {
-    return constraintDecorator<AllowedPropertyTypes>((schema: Schema) => {
-        return (schema as ArraySchema).sparse(enabled);
+    return constraintDecorator<AllowedPropertyTypes>((schema: JoiModule.Schema) => {
+        return (schema as JoiModule.ArraySchema).sparse(enabled);
     });
 }
 
@@ -75,7 +97,7 @@ export function Sparse(enabled?: boolean | any): TypedPropertyDecorator<AllowedP
  * Requires the array values to be unique.
  */
 export function Unique(): TypedPropertyDecorator<AllowedPropertyTypes> {
-    return constraintDecorator<AllowedPropertyTypes>((schema: Schema) => {
-        return (schema as ArraySchema).unique();
+    return constraintDecorator<AllowedPropertyTypes>((schema: JoiModule.Schema) => {
+        return (schema as JoiModule.ArraySchema).unique();
     });
 }

--- a/test/unit/constraints/array.test.ts
+++ b/test/unit/constraints/array.test.ts
@@ -1,0 +1,58 @@
+import { Items } from '../../../src/constraints/array';
+import { Joi } from '../../../src/core';
+import { testConstraintWithPojos } from '../testUtil';
+
+describe('Array constraints', () => {
+    describe('Items', () => {
+        describe('when using fluent API', () => {
+            const getClass = () => {
+                class MoviesQuiz {
+                    @Items((joi) => joi.string().empty('').required().min(6))
+                    favouriteMovies!: string[];
+                }
+
+                return MoviesQuiz;
+            };
+
+            testConstraintWithPojos(
+                getClass,
+                [{ favouriteMovies: ['Citizen Kane', 'Casablanca', 'The Matrix Reloaded: Revenge of the Smiths'] }],
+                [{ favouriteMovies: [''] }, { favouriteMovies: true }],
+            );
+        });
+
+        describe('when using fluent API returning array of types', () => {
+            const getClass = () => {
+                class MoviesQuiz {
+                    @Items((joi) => [joi.string().empty('').required().min(6), joi.number().required()])
+                    favouriteMovies!: (string | number)[];
+                }
+
+                return MoviesQuiz;
+            };
+
+            testConstraintWithPojos(
+                getClass,
+                [{ favouriteMovies: ['Citizen Kane', 'Casablanca', 'The Matrix Reloaded: Revenge of the Smiths', 7] }],
+                [{ favouriteMovies: [''] }, { favouriteMovies: [false as any] }],
+            );
+        });
+
+        describe('when not using fluent API', () => {
+            const getClass = () => {
+                class MoviesQuiz {
+                    @Items(Joi.string().empty('').required().min(6), Joi.number())
+                    favouriteMovies!: (string | number)[];
+                }
+
+                return MoviesQuiz;
+            };
+
+            testConstraintWithPojos(
+                getClass,
+                [{ favouriteMovies: ['Citizen Kane', 'Casablanca', 'The Matrix Reloaded: Revenge of the Smiths', 7] }],
+                [{ favouriteMovies: [''] }, { favouriteMovies: ['Big'] }, { favouriteMovies: false as any }],
+            );
+        });
+    });
+});


### PR DESCRIPTION
Closes #38 by adding fluent API syntax to the `Items` decorator.

e.g.

```typescript
class MoviesQuiz {
    @Items((joi) => joi.string())
    favouriteMovies!: string[];
}
```

Also allows multiple item schemas:

```typescript
class MoviesQuiz {
    @Items((joi) => [joi.string(), joi.number()])
    favouriteMovies!: (string | number)[];
}
```

Backwards compatible with previous style:

```typescript
import { Joi } from 'tsdv-joi/core';

class MoviesQuiz {
    @Items(Joi.string(), Joi.number())
    favouriteMovies!: (string | number)[];
}
```