### PR TITLE
Upgrade to joi v15, make joi normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,21 +36,20 @@
         "test": "jest",
         "watch": "tsc -p tsconfig.all.json -w --noEmit"
     },
-    "peerDependencies": {
-        "@types/joi": "^10.4.1",
-        "joi": "^10.6.0"
+    "dependencies": {
+        "@hapi/joi": "15.1.1",
+        "@types/hapi__joi": "15.0.3"
     },
     "devDependencies": {
         "@types/jest": "24.0.11",
-        "@types/joi": "10.4.1",
         "@types/node": "6.0.63",
         "@types/reflect-metadata": "0.0.5",
         "@types/rimraf": "0.0.28",
         "case": "1.6.2",
+        "flatted": "2.0.1",
         "get-root-path": "2.0.2",
         "husky": "2.3.0",
         "jest": "24.7.1",
-        "joi": "10.6.0",
         "reflect-metadata": "0.1.9",
         "rimraf": "2.6.0",
         "ts-jest": "24.0.2",

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 
 export const getJoi = (options: { joi?: typeof Joi } | undefined = {}) => options.joi || Joi;
 

--- a/src/decorators/any.ts
+++ b/src/decorators/any.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { createPropertyDecorator, JoifulOptions, ModifierProviders, NotImplemented } from './common';
 import { TypedPropertyDecorator } from '../core';
 

--- a/src/decorators/array.ts
+++ b/src/decorators/array.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { TypedPropertyDecorator, AnyClass, getJoiSchema } from '../core';
 import { ModifierProviders, JoifulOptions, createPropertyDecorator } from './common';
 import { AnySchemaModifiers, getAnySchemaModifierProviders } from './any';

--- a/src/decorators/boolean.ts
+++ b/src/decorators/boolean.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { TypedPropertyDecorator } from '../core';
 import { ModifierProviders, JoifulOptions, createPropertyDecorator } from './common';
 import { AnySchemaModifiers, getAnySchemaModifierProviders } from './any';

--- a/src/decorators/common.ts
+++ b/src/decorators/common.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { getJoi, TypedPropertyDecorator, MapAllowUnions, StringOrSymbolKey, updateSchema } from '../core';
 
 export class NotImplemented extends Error {

--- a/src/decorators/date.ts
+++ b/src/decorators/date.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { TypedPropertyDecorator } from '../core';
 import { ModifierProviders, createPropertyDecorator, JoifulOptions } from './common';
 import { AnySchemaModifiers, getAnySchemaModifierProviders } from './any';

--- a/src/decorators/function.ts
+++ b/src/decorators/function.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { TypedPropertyDecorator } from '../core';
 import { ModifierProviders, createPropertyDecorator, JoifulOptions } from './common';
 import { AnySchemaModifiers, getAnySchemaModifierProviders } from './any';

--- a/src/decorators/lazy.ts
+++ b/src/decorators/lazy.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { TypedPropertyDecorator } from '../core';
 import { ModifierProviders, createPropertyDecorator, JoifulOptions } from './common';
 import { AnySchemaModifiers, getAnySchemaModifierProviders } from './any';

--- a/src/decorators/number.ts
+++ b/src/decorators/number.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { TypedPropertyDecorator } from '../core';
 import { ModifierProviders, JoifulOptions, createPropertyDecorator } from './common';
 import { AnySchemaModifiers, getAnySchemaModifierProviders } from './any';

--- a/src/decorators/object.ts
+++ b/src/decorators/object.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { TypedPropertyDecorator, getJoiSchema, AnyClass } from '../core';
 import { ModifierProviders, JoifulOptions, createPropertyDecorator } from './common';
 import { AnySchemaModifiers, getAnySchemaModifierProviders } from './any';

--- a/src/decorators/string.ts
+++ b/src/decorators/string.ts
@@ -1,8 +1,8 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { TypedPropertyDecorator } from '../core';
 import { ModifierProviders, JoifulOptions, createPropertyDecorator } from './common';
 import { AnySchemaModifiers, getAnySchemaModifierProviders } from './any';
-import { EmailOptions } from 'joi';
+import { EmailOptions } from '@hapi/joi';
 
 export interface StringSchemaModifiers extends AnySchemaModifiers {
     /**

--- a/src/joiful.ts
+++ b/src/joiful.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { JoifulOptions } from './decorators/common';
 import { createAnyPropertyDecorator } from './decorators/any';
 import { createArrayPropertyDecorator, ArrayPropertyDecoratorOptions } from './decorators/array';

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,5 +1,5 @@
 import { getJoi, getJoiSchema, AnyClass, WORKING_SCHEMA_KEY, Constructor } from './core';
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 
 export class MultipleValidationError extends Error {
     constructor(
@@ -96,7 +96,10 @@ export class Validator {
             joi.validate(target, classSchema, options) :
             joi.validate(target, classSchema);
 
-        return result as ValidationResult<TInstance>;
+        return {
+            ...result,
+            value: result.value as TInstance,
+        };
     }
 
     /**
@@ -125,7 +128,10 @@ export class Validator {
             joi.validate(target, arraySchema, options) :
             joi.validate(target, arraySchema);
 
-        return result as ValidationResult<TInstance[]>;
+        return {
+            ...result,
+            value: result.value as TInstance[],
+        };
     }
 }
 

--- a/test/unit/core.test.ts
+++ b/test/unit/core.test.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import * as jf from '../../src';
 import {
     getJoiSchema,
@@ -9,6 +9,7 @@ import {
     parseVersionString,
 } from '../../src/core';
 import { getJoifulDependencyVersion } from './testUtil';
+import { stringify } from 'flatted';
 
 describe('checkJoiIsCompatible', () => {
     it('should not error if version of joi passed in matches expected major version', () => {
@@ -65,7 +66,7 @@ describe('getJoiSchema', () => {
             fluffinessIndex: jf.joi.number().min(1).max(5),
         });
 
-        expect(JSON.stringify(getJoiSchema(Cat, jf.joi))).toEqual(JSON.stringify(expectedSchema));
+        expect(stringify(getJoiSchema(Cat, jf.joi))).toEqual(stringify(expectedSchema));
     });
 });
 
@@ -73,6 +74,12 @@ describe('getJoiVersion', () => {
     const mockJoi = (version: string | undefined) => ({ version }) as any as typeof Joi;
 
     it('should return the version of joi', () => {
+        expect(getJoiVersion(Joi)).not.toEqual({
+            major: '?',
+            minor: '?',
+            patch: '?',
+        });
+
         expect(getJoiVersion(mockJoi('1.2.3'))).toEqual({
             major: '1',
             minor: '2',
@@ -103,7 +110,7 @@ describe('getJoiVersion', () => {
 
 describe('JOI_VERSION', () => {
     it('should match the version of joi referenced in Joifuls package dependencies', async () => {
-        const expectedJoiVersion = await getJoifulDependencyVersion('joi');
+        const expectedJoiVersion = await getJoifulDependencyVersion('@hapi/joi');
         expect(expectedJoiVersion.major).toBeTruthy();
 
         const actualJoiVersion = JOI_VERSION;

--- a/test/unit/decorators/any.test.ts
+++ b/test/unit/decorators/any.test.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { testConstraint, assertClassSchemaEquals } from '../testUtil';
 import * as jf from '../../../src';
 import { getJoiSchema } from '../../../src/core';
@@ -167,7 +167,7 @@ describe('any', () => {
         it('should throw NotImplementedError if joi does not support custom errors', () => {
             const disableCustomErrorsForSchema = ({ schema }: { schema: Joi.Schema }) => {
                 const { error, ...newSchema } = schema;
-                return newSchema;
+                return newSchema as Joi.Schema;
             };
 
             function getClass() {
@@ -294,7 +294,7 @@ describe('any', () => {
 
     describe('meta', () => {
         class User {
-            @jf.string().meta('some metadata')
+            @jf.string().meta({ value: 'some metadata' })
             name?: string;
         }
 
@@ -302,7 +302,7 @@ describe('any', () => {
             assertClassSchemaEquals({
                 Class: User,
                 expectedSchemaMap: {
-                    name: jf.joi.string().meta('some metadata'),
+                    name: jf.joi.string().meta({ value: 'some metadata' }),
                 },
             });
         });

--- a/test/unit/decorators/string.test.ts
+++ b/test/unit/decorators/string.test.ts
@@ -63,9 +63,9 @@ describe('string', () => {
             [
                 { emailAddress: 'monkey@see.com' },
                 { emailAddress: 'howdy+there@pardner.co.kr' },
-                { emailAddress: 'monkey@do' },
             ],
             [
+                { emailAddress: 'monkey@do' },
                 { emailAddress: '' },
                 { emailAddress: '123.com' },
             ],
@@ -239,12 +239,11 @@ describe('string', () => {
                 },
                 [
                     { ipAddress: '127.0.0.1/24' },
+                    { ipAddress: '2001:db8:abcd:8000::/50' },
                 ],
                 [
                     { ipAddress: '127.0.0.1' },
                     { ipAddress: '2001:0db8:0000:0000:0000:ff00:0042:8329' },
-                    { ipAddress: '2001:db8:abcd:8000::/50' },
-                    { ipAddress: '2001:db8:abcd:8000::/50' },
                 ],
             );
         });

--- a/test/unit/examples.test.ts
+++ b/test/unit/examples.test.ts
@@ -1,5 +1,5 @@
 import { getJoiSchema } from '../../src/core';
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { joi, lazy, object, string } from '../../src';
 import { testConstraint } from './testUtil';
 

--- a/test/unit/joiful.test.ts
+++ b/test/unit/joiful.test.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { testConstraint } from './testUtil';
 import { Joiful, string, boolean } from '../../src';
 import { Validator, MultipleValidationError } from '../../src/validation';

--- a/test/unit/testUtil.ts
+++ b/test/unit/testUtil.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 import { rootPath } from 'get-root-path';
 import * as path from 'path';
 import * as fs from 'fs';

--- a/test/unit/validation.test.ts
+++ b/test/unit/validation.test.ts
@@ -28,7 +28,7 @@ describe('ValidationResult', () => {
                     {
                         message: "'email' is not a valid email",
                         type: 'email',
-                        path: 'emailAddress',
+                        path: ['emailAddress'],
                     },
                 ],
                 annotate: () => '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,6 +124,38 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@hapi/address@2.x.x":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"
+  integrity sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==
+
+"@hapi/bourne@1.x.x":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
+  integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
+
+"@hapi/hoek@8.x.x":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.2.1.tgz#924af04cbb22e17359c620d2a9c946e63f58eb77"
+  integrity sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg==
+
+"@hapi/joi@15.1.1":
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.1.tgz#c675b8a71296f02833f8d6d243b34c57b8ce19d7"
+  integrity sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==
+  dependencies:
+    "@hapi/address" "2.x.x"
+    "@hapi/bourne" "1.x.x"
+    "@hapi/hoek" "8.x.x"
+    "@hapi/topo" "3.x.x"
+
+"@hapi/topo@3.x.x":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.3.tgz#c7a02e0d936596d29f184e6d7fdc07e8b5efce11"
+  integrity sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==
+  dependencies:
+    "@hapi/hoek" "8.x.x"
+
 "@jest/console@^24.7.1":
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
@@ -287,6 +319,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/hapi__joi@*", "@types/hapi__joi@15.0.3":
+  version "15.0.3"
+  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-15.0.3.tgz#eeeca99e3829636975bf39532d6e8279409c78f2"
+  integrity sha512-kncvQstpAQSjQ+J+tL2oYerjOEepv+yJHKM/JD/NmFZyDcy3rYOBcMJhdHRDjBxuSZu3ipGECszhgtmug9VSuw==
+  dependencies:
+    "@types/hapi__joi" "*"
+
 "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -300,10 +339,6 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.11.tgz#1f099bea332c228ea6505a88159bfa86a5858340"
   dependencies:
     "@types/jest-diff" "*"
-
-"@types/joi@10.4.1":
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/@types/joi/-/joi-10.4.1.tgz#30e987649cede8d2a78829489857e969a81e1e99"
 
 "@types/node@6.0.63":
   version "6.0.63"
@@ -1109,6 +1144,11 @@ find-up@^4.0.0:
   dependencies:
     locate-path "^5.0.0"
 
+flatted@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
+  integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1287,10 +1327,6 @@ has@^1.0.1, has@^1.0.3:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   dependencies:
     function-bind "^1.1.1"
-
-hoek@4.x.x:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
 hosted-git-info@^2.1.4:
   version "2.7.1"
@@ -1522,10 +1558,6 @@ isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-isemail@2.x.x:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-2.2.1.tgz#0353d3d9a62951080c262c2aa0a42b8ea8e9e2a6"
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1607,10 +1639,6 @@ istanbul-reports@^2.2.3:
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.3.tgz#14e0d00ecbfa9387757999cf36599b88e9f2176e"
   dependencies:
     handlebars "^4.1.0"
-
-items@2.x.x:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/items/-/items-2.1.2.tgz#0849354595805d586dac98e7e6e85556ea838558"
 
 jest-changed-files@^24.7.0:
   version "24.7.0"
@@ -1935,15 +1963,6 @@ jest@24.7.1:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.7.1"
-
-joi@10.6.0:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-10.6.0.tgz#52587f02d52b8b75cdb0c74f0b164a191a0e1fc2"
-  dependencies:
-    hoek "4.x.x"
-    isemail "2.x.x"
-    items "2.x.x"
-    topo "2.x.x"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -3188,12 +3207,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
-
-topo@2.x.x:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
-  dependencies:
-    hoek "4.x.x"
 
 tough-cookie@^2.3.3, tough-cookie@^2.3.4:
   version "2.5.0"


### PR DESCRIPTION
### Summary
- Upgrades joi to v15 (`@hapi/joi`)
  - Was actually pretty painless
  - A couple tests needed updating as joi fixed a couple issues and the fixes broke the tests
  - Didn't run into any issues with dates. Seems date validation is still supported by v15.
- Made joi a regular dependency (not a peer dependency)

Closes #21 and closes #22.