### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![npm version](https://badge.fury.io/js/joiful.svg)](https://badge.fury.io/js/joiful)
 [![CircleCI](https://circleci.com/gh/joiful-ts/joiful.svg?style=shield)](https://circleci.com/gh/joiful-ts/joiful)
+[![codecov](https://codecov.io/gh/joiful-ts/joiful/branch/master/graph/badge.svg)](https://codecov.io/gh/joiful-ts/joiful)
 
 This lib allows you to apply Joi validation constraints on class properties, by using decorators.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# tsdv-joi - TypeScript Declarative Validation for Joi
+# joiful
+#### TypeScript Declarative Validation for Joi
 
-[![CircleCI](https://circleci.com/gh/laurence-myers/tsdv-joi.svg?style=shield)](https://circleci.com/gh/laurence-myers/tsdv-joi)
+[![npm version](https://badge.fury.io/js/joiful.svg)](https://badge.fury.io/js/joiful)
+[![CircleCI](https://circleci.com/gh/joiful-ts/joiful.svg?style=shield)](https://circleci.com/gh/joiful-ts/joiful)
 
 This lib allows you to apply Joi validation constraints on class properties, by using decorators.
 
@@ -8,64 +10,103 @@ This means you can combine your type schema and your validation schema in one go
 
 Calling `Validator.validateAsClass()` allows you to validate any object as if it were an instance of a given class.
 
+
 ## Installation
+
+`npm add joiful`
+
+Or
+
+`yarn add joiful`.
 
 You must enable experimental decorators and metadata in your TypeScript configuration.
 
-## Usage
-
-```typescript
-// ...imports...
-
-registerJoi(Joi);
-
-class MyClass {
-	@Max(5)
-	@Min(2)
-	@StringSchema
-	public myProperty! : string;
-}
-
-let instance = new MyClass();
-instance.myProperty = "a";
-
-const validator = new Validator();
-var result = validator.validate(instance);
-console.log(result); // outputs the Joi returned value
-```
-
-## Custom constraints
-
-You can provide your own decorators to chain together Joi constraints.
-
-```typescript
-export function RequiredPositiveInteger() : PropertyDecorator {
-    return constraintDecorator([Number], (schema : NumberSchema) => {
-        return schema.required().positive().integer().min(1);
-    });
-}
-
-class MyClass {
-    @RequiredPositiveInteger()
-    public myProperty! : number;
+`tsconfig.json`
+```json
+{
+    "compilerOptions": {
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+    }
 }
 ```
 
-If you want to provide your own validation functions, you can use Joi's "extend" functionality, and register your
-instance of Joi with tsdv-joi by calling `core/registerJoi()`. Refer to the Joi documentation for details on extending
-Joi.
 
-## TODO:
+## Basic Usage
 
-- Tests! Tests! TEEEESSSSTTS!
-- Custom constraints without having to extend Joi.
-- Don't make the registered Joi module a singleton.
-- Abstract message into property keys (for i18n support). (Can be achieved through validator config)
-- Support some object constraints at the class level, e.g. and/nand/or/xor.
-- Support "alternatives", other Joi functions.
+```typescript
+import * as jf from 'joiful';
+
+class SignUp {
+	@jf.string().required()
+    username: string;
+
+    @jf.string().required().min(8)
+    password: string;
+
+    @jf.date()
+    dateOfBirth: Date;
+
+    @jf.boolean().required()
+    subscribedToNewsletter: boolean;
+}
+
+const signUp = new SignUp();
+signUp.username = 'rick.sanchez';
+signUp.password = 'wubbalubbadubdub';
+
+const { error } = jf.validate(signUp);
+
+console.log(error); // Error will either be undefined or a standard joi validation error
+```
+
+## Validate plain old javascript objects
+Don't like creating instances of classes? Don't worry, you don't have to. You can validate a plain old javascript object as if it were an instance of a class.
+
+```typescript
+const signUp = {
+    username: 'rick.sanchez',
+    password: 'wubbalubbadubdub'
+};
+
+const result = jf.validateAsClass(signUp, SignUp);
+```
+
+## Custom decorator constraints
+Want to create your own shorthand versions of decorators? Simply create a function like below.
+
+`customDecorators.ts`
+```typescript
+import * as jf from 'joiful';
+
+const password = () => jf.string()
+    .min(8)
+    .regex(/[a-z]/)
+    .regex(/[A-Z]/)
+    .regex(/[0-9]/)
+    .required();
+```
+
+`changePassword.ts`
+```typescript
+import { password } from './customDecorators';
+
+class ChangePassword {
+    @password()
+    newPassword: string;
+}
+```
+
+
+## Contributing
+Got an issue or a feature request? [Log it](https://github.com/joiful-ts/joiful/issues).
+
+[Pull-requests](https://github.com/joiful-ts/joiful/pulls) are also welcome.
+
 
 ## Alternatives
 
 - [class-validator](https://github.com/typestack/class-validator): usable in both Node.js and the browser. Mostly designed for validating string values. Can't validate plain objects, only class instances.
 - [joi-extract-type](https://github.com/TCMiranda/joi-extract-type): provides native type extraction from Joi Schemas. Augments the Joi type definitions.
 - [typesafe-joi](https://github.com/hjkcai/typesafe-joi): automatically infers type information of validated objects, via the standard Joi schema API.
+

--- a/package.json
+++ b/package.json
@@ -41,12 +41,14 @@
         "@types/hapi__joi": "15.0.3"
     },
     "devDependencies": {
+        "@types/fs-extra": "8.0.0",
         "@types/jest": "24.0.11",
         "@types/node": "6.0.63",
         "@types/reflect-metadata": "0.0.5",
         "@types/rimraf": "0.0.28",
         "case": "1.6.2",
         "flatted": "2.0.1",
+        "fs-extra": "8.1.0",
         "get-root-path": "2.0.2",
         "husky": "2.3.0",
         "jest": "24.7.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,13 @@
 import { Joiful } from './joiful';
+import { Validator } from './validation';
 
 export { Validator, MultipleValidationError, ValidationResult, isValidationPass, isValidationFail } from './validation';
 export { Joiful } from './joiful';
 
 export const DEFAULT_INSTANCE = new Joiful();
+
+const DEFAULT_VALIDATOR = new Validator();
+const { validate, validateAsClass, validateArrayAsClass } = DEFAULT_VALIDATOR;
 
 const {
     any,
@@ -16,7 +20,7 @@ const {
     number,
     object,
     string,
-    validate,
+    validateParams,
 } = DEFAULT_INSTANCE;
 
 export {
@@ -31,4 +35,7 @@ export {
     object,
     string,
     validate,
+    validateAsClass,
+    validateArrayAsClass,
+    validateParams,
 };

--- a/src/joiful.ts
+++ b/src/joiful.ts
@@ -78,7 +78,7 @@ export class Joiful {
     string = () => createStringPropertyDecorator(this.options);
 
     /**
-     * Method decorator that validates that parameters passed into the method.
+     * Method decorator that validates the parameters passed into the method.
      */
-    validate = (options?: { validator?: Validator }) => createValidatePropertyDecorator(options);
+    validateParams = (options?: { validator?: Validator }) => createValidatePropertyDecorator(options);
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -64,7 +64,7 @@ export class Validator {
      * @param target Instance of decorated class to validate.
      * @param options Optional validation options to use.
      */
-    validate<T extends {} | null | undefined>(target: T, options?: ValidationOptions): ValidationResult<T> {
+    validate = <T extends {} | null | undefined>(target: T, options?: ValidationOptions): ValidationResult<T> => {
         if (target === null || target === undefined) {
             throw new InvalidValidationTarget();
         }
@@ -77,14 +77,14 @@ export class Validator {
      * @param clz Decorated class to validate against.
      * @param options Optional validation options to use.
      */
-    validateAsClass<
+    validateAsClass = <
         TClass extends Constructor<any>,
         TInstance = TClass extends Constructor<infer TInstance> ? TInstance : never
     >(
         target: Partial<TInstance> | null | undefined,
         Class: TClass,
         options: ValidationOptions | undefined = this.defaultOptions,
-    ): ValidationResult<TInstance> {
+    ): ValidationResult<TInstance> => {
         if (target === null || target === undefined) {
             throw new InvalidValidationTarget();
         }
@@ -108,14 +108,14 @@ export class Validator {
      * @param clz Decorated class to validate against.
      * @param options Optional validation options to use.
      */
-    validateArrayAsClass<
+    validateArrayAsClass = <
         TClass extends Constructor<any>,
         TInstance = TClass extends Constructor<infer TInstance> ? TInstance : never
     >(
         target: Partial<TInstance>[],
         Class: TClass,
         options: ValidationOptions | undefined = this.defaultOptions,
-    ): ValidationResult<TInstance[]> {
+    ): ValidationResult<TInstance[]> => {
         if (target === null || target === undefined) {
             throw new InvalidValidationTarget();
         }

--- a/test/unit/joiful.test.ts
+++ b/test/unit/joiful.test.ts
@@ -174,7 +174,7 @@ describe('validate', () => {
         }
 
         class PasscodeChecker {
-            @jf.validate()
+            @jf.validateParams()
             check(passcode: Passcode, basicArg: number) {
                 expect(passcode).not.toBeNull();
                 expect(basicArg).not.toBeNull();
@@ -204,7 +204,7 @@ describe('validate', () => {
         }));
 
         class PasscodeChecker {
-            @jf.validate({ validator })
+            @jf.validateParams({ validator })
             check(passcode: Passcode, basicArg: number) {
                 expect(passcode).not.toBeNull();
                 expect(basicArg).not.toBeNull();

--- a/test/unit/validation.test.ts
+++ b/test/unit/validation.test.ts
@@ -1,4 +1,13 @@
-import { string, Validator, ValidationResult, isValidationPass, isValidationFail } from '../../src';
+import {
+    string,
+    validate,
+    validateAsClass,
+    validateArrayAsClass,
+    Validator,
+    ValidationResult,
+    isValidationPass,
+    isValidationFail,
+} from '../../src';
 import { InvalidValidationTarget } from '../../src/validation';
 
 interface ResetPasswordForm {
@@ -58,7 +67,7 @@ describe('ValidationResult', () => {
     });
 });
 
-describe('Validator', () => {
+describe('Validation', () => {
     class Login {
         @string()
         emailAddress?: string;
@@ -67,15 +76,18 @@ describe('Validator', () => {
         password?: string;
     }
 
+    let login: Login;
+
+    beforeEach(() => {
+        login = new Login();
+        login.emailAddress = 'joe@example.com';
+    });
+
     describe('Validator', () => {
         let validator: Validator;
-        let login: Login;
 
         beforeEach(() => {
             validator = new Validator();
-
-            login = new Login();
-            login.emailAddress = 'joe@example.com';
         });
 
         describe('constructor', () => {
@@ -149,4 +161,61 @@ describe('Validator', () => {
             });
         });
     });
+
+    describe('validate', () => {
+        it('should validate an instance of a decorated class', () => {
+            const result = validate(login);
+            expect(result.value).toEqual(login);
+            expect(result.error).toBe(null);
+        });
+
+        it('should optionally accept validation options to use', () => {
+            const result = validate(login, { presence: 'required' });
+            expect(result.value).toEqual(login);
+            expect(result.error).toBeTruthy();
+        });
+
+        it('should error when trying to validate null', () => {
+            expect(() => validate(null)).toThrowError(new InvalidValidationTarget());
+        });
+    });
+
+    describe('validateAsClass', () => {
+        it('should accept a plain old javascript object to validate', () => {
+            const result = validateAsClass({ ...login }, Login);
+            expect(result.value).toEqual(login);
+            expect(result.error).toBe(null);
+        });
+
+        it('should optionally accept validation options to use', () => {
+            const result = validateAsClass({ ...login }, Login, { presence: 'required' });
+            expect(result.value).toEqual(login);
+            expect(result.error).toBeTruthy();
+        });
+
+        it('should error when trying to validate null', () => {
+            expect(() => validateAsClass(null, Login)).toThrowError(new InvalidValidationTarget());
+        });
+    });
+
+    describe('validateArrayAsClass', () => {
+        it('should accept an array of plain old javascript objects to validate', () => {
+            const result = validateArrayAsClass([{ ...login }], Login);
+            expect(result.value).toEqual([login]);
+            expect(result.error).toBe(null);
+        });
+
+        it('should optionally accept validation options to use', () => {
+            const result = validateArrayAsClass([{ ...login }], Login, { presence: 'required' });
+            expect(result.value).toEqual([login]);
+            expect(result.error).toBeTruthy();
+        });
+
+        it('should error when trying to validate null', () => {
+            expect(
+                () => validateArrayAsClass(null as any, Login),
+            ).toThrowError(new InvalidValidationTarget());
+        });
+    });
 });
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,6 +319,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/fs-extra@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.0.0.tgz#d3e2c313ca29f95059f198dd60d1f774642d4b25"
+  integrity sha512-bCtL5v9zdbQW86yexOlXWTEGvLNqWxMFyi7gQA7Gcthbezr2cPSOb8SkESVKA937QD5cIwOFLDFt0MQoXOEr9Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/hapi__joi@*", "@types/hapi__joi@15.0.3":
   version "15.0.3"
   resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-15.0.3.tgz#eeeca99e3829636975bf39532d6e8279409c78f2"
@@ -339,6 +346,11 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.11.tgz#1f099bea332c228ea6505a88159bfa86a5858340"
   dependencies:
     "@types/jest-diff" "*"
+
+"@types/node@*":
+  version "12.7.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
+  integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
 
 "@types/node@6.0.63":
   version "6.0.63"
@@ -1171,6 +1183,15 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fs-extra@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -1257,6 +1278,11 @@ globals@^11.1.0:
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
+  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -2035,6 +2061,13 @@ json5@2.x, json5@^2.1.0:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
   dependencies:
     minimist "^1.2.0"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -3357,6 +3390,11 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### Summary
- Updates README by
  - Add npm version badge
  - Adding install commands
  - Update examples with new API
  - General tidy up

- Made `Validator` methods available as individual functions exported from main. Had to rename `validate` decorator to `validateParams` to make room for the `validate` function from `Validator`. This is similar to how we export methods from the default `Joiful` instance to save app developers from having to create their own `Joiful` instance. For convenience we now have a default `Validator` instance we export methods from as well.

- Improved package script to better support packaging files in sub-directories (e.g. images/logo.png). Note, I've held off proposing a logo design in this PR - I want to play around with it a bit more and didn't want to hold up this PR.