### PR TITLE
Add/fix keywords in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,22 @@
         "Ben <codeandcats@gmail.com> (https://github.com/codeandcats)",
         "Laurence Dougal Myers <laurencedougalmyers@gmail.com>"
     ],
-    "tags": [
+    "keywords": [
+        "class",
+        "constrain",
+        "constraint",
+        "declarative",
         "decorator",
+        "decorators",
         "joi",
+        "model",
         "schema",
+        "tsdv",
+        "tsdv-joi",
         "typescript",
-        "typescript-validator",
+        "validate",
         "validator",
+        "validators",
         "validation"
     ],
     "engines": {


### PR DESCRIPTION
Renamed `"tags"` in `package.json` to correct name `"keywords"` and updated keywords.

Closes #66 