### PR TITLE
Feature Request: Export getSchema, hasSchema functions

### DIFF
--- a/src/decorators/array.ts
+++ b/src/decorators/array.ts
@@ -133,7 +133,9 @@ export const createArrayPropertyDecorator = (
 
             if (elementClass) {
                 const elementSchema = getJoiSchema(elementClass, joi);
-                schema = schema.items(elementSchema);
+                if (elementSchema) {
+                    schema = schema.items(elementSchema);
+                }
             }
 
             return schema;

--- a/src/decorators/common.ts
+++ b/src/decorators/common.ts
@@ -1,5 +1,5 @@
 import * as Joi from '@hapi/joi';
-import { getJoi, TypedPropertyDecorator, MapAllowUnions, StringOrSymbolKey, updateSchema } from '../core';
+import { getJoi, TypedPropertyDecorator, MapAllowUnions, StringOrSymbolKey, updateWorkingSchema } from '../core';
 
 export class NotImplemented extends Error {
     constructor(feature: string) {
@@ -93,7 +93,7 @@ export const createPropertyDecorator = <TAllowedTypes, TSchemaModifiers>() => (
                 schema = modifierToApply({ schema: schema!, options });
             });
 
-            updateSchema(target, propertyKey, schema);
+            updateWorkingSchema(target, propertyKey, schema);
         };
 
         const decorator = decoratorUntyped as PropertyDecorator<TAllowedTypes, TSchemaModifiers>;

--- a/src/decorators/object.ts
+++ b/src/decorators/object.ts
@@ -38,9 +38,9 @@ export const createObjectPropertyDecorator = (
                     options.objectClass :
                     Reflect.getMetadata('design:type', target, propertyKey);
 
-                const schema = (elementType && elementType !== Object) ?
-                    getJoiSchema(elementType, joi) :
-                    joi.object();
+                const schema = (
+                    (elementType && elementType !== Object) && getJoiSchema(elementType, joi)
+                 ) || joi.object();
 
                 return schema;
             },

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ const {
     object,
     string,
     validateParams,
+    getSchema,
+    hasSchema,
 } = DEFAULT_INSTANCE;
 
 export {
@@ -38,4 +40,6 @@ export {
     validateAsClass,
     validateArrayAsClass,
     validateParams,
+    getSchema,
+    hasSchema,
 };

--- a/src/joiful.ts
+++ b/src/joiful.ts
@@ -10,7 +10,7 @@ import { createNumberPropertyDecorator } from './decorators/number';
 import { createObjectPropertyDecorator, ObjectPropertyDecoratorOptions } from './decorators/object';
 import { createStringPropertyDecorator } from './decorators/string';
 import { Validator, createValidatePropertyDecorator } from './validation';
-import { checkJoiIsCompatible, getJoi } from './core';
+import { AnyClass, checkJoiIsCompatible, getJoi, getJoiSchema } from './core';
 
 export class Joiful {
     constructor(private readonly options: JoifulOptions = {}) {
@@ -81,4 +81,16 @@ export class Joiful {
      * Method decorator that validates the parameters passed into the method.
      */
     validateParams = (options?: { validator?: Validator }) => createValidatePropertyDecorator(options);
+
+    /**
+     * Returns the Joi schema associated with a class or undefined if there isn't one.
+     */
+    getSchema = (Class: AnyClass): Joi.ObjectSchema | undefined => {
+        return getJoiSchema(Class, this.joi);
+    }
+
+    /**
+     * Returns whether the given class has a Joi schema associated with it
+     */
+    hasSchema = (Class: AnyClass) => Boolean(this.getSchema(Class));
 }

--- a/test/unit/core.test.ts
+++ b/test/unit/core.test.ts
@@ -36,12 +36,14 @@ describe('getJoiSchema', () => {
         expect(getJoiSchema(Cat, jf.joi)).toEqual(jf.joi.object().keys({
             name: jf.joi.string(),
         }));
+    });
 
+    it('should return no schema when class is not decorated', () => {
         class Dog {
             name!: string;
         }
 
-        expect(getJoiSchema(Dog, jf.joi)).toEqual(jf.joi.object().keys({}));
+        expect(getJoiSchema(Dog, jf.joi)).toBeUndefined();
     });
 
     it('should support inheritance in classes', () => {

--- a/test/unit/decorators/lazy.test.ts
+++ b/test/unit/decorators/lazy.test.ts
@@ -9,7 +9,7 @@ describe('lazy', () => {
                 @string()
                 title!: string;
 
-                @lazy(({ joi }) => joi.array().items(getJoiSchema(TreeNode, joi))).optional()
+                @lazy(({ joi }) => joi.array().items(getJoiSchema(TreeNode, joi)!)).optional()
                 children?: TreeNode[];
             }
             return TreeNode;

--- a/test/unit/examples.test.ts
+++ b/test/unit/examples.test.ts
@@ -79,7 +79,7 @@ describe('Examples', () => {
             @string().required()
             tagName!: string;
 
-            @lazy(() => Joi.array().items(getJoiSchema(TreeNode, joi)))
+            @lazy(() => Joi.array().items(getJoiSchema(TreeNode, joi)!))
             children!: TreeNode[];
         }
 

--- a/test/unit/inheritance.test.ts
+++ b/test/unit/inheritance.test.ts
@@ -2,6 +2,7 @@ import './testUtil';
 import { Joiful } from '../../src/joiful';
 import { Validator } from '../../src/validation';
 import { getMergedWorkingSchemas, getWorkingSchema } from '../../src/core';
+import { notNil } from './testUtil';
 
 let jf: Joiful;
 
@@ -25,15 +26,15 @@ describe('Inheritance', () => {
             bar!: number;
         }
 
-        const parentSchemaUnmerged = getWorkingSchema(ParentClass.prototype);
+        const parentSchemaUnmerged = notNil(getWorkingSchema(ParentClass.prototype));
         expect(parentSchemaUnmerged.foo).toBeDefined();
         expect(parentSchemaUnmerged.bar).toBeUndefined();
 
-        const parentSchema = getMergedWorkingSchemas(ParentClass.prototype);
+        const parentSchema = notNil(getMergedWorkingSchemas(ParentClass.prototype));
         expect(parentSchema.foo).toBeDefined();
         expect(parentSchema.bar).toBeUndefined();
 
-        const childSchema = getMergedWorkingSchemas(ChildClass.prototype);
+        const childSchema = notNil(getMergedWorkingSchemas(ChildClass.prototype));
         expect(childSchema.foo).toBeDefined();
         expect(childSchema.bar).toBeDefined();
     });

--- a/test/unit/joiful.test.ts
+++ b/test/unit/joiful.test.ts
@@ -159,6 +159,42 @@ describe('joiful', () => {
                 expect(result.error!.message).toContain('signUpForSpam');
             });
         });
+
+        it('should provide method to get the Joi schema for a class', () => {
+            class ForgotPassword {
+                emailAddress?: string;
+            }
+
+            expect(jf.getSchema(ForgotPassword)).toBe(undefined);
+
+            class Login {
+                @jf.string().email().required()
+                emailAddress?: string;
+
+                @jf.string().min(8).required()
+                password?: string;
+            }
+
+            expect(jf.getSchema(Login)).toBeTruthy();
+        });
+
+        it('should provide method to test if class has a schema', () => {
+            class ForgotPassword {
+                emailAddress?: string;
+            }
+
+            expect(jf.hasSchema(ForgotPassword)).toBe(false);
+
+            class Login {
+                @jf.string().email().required()
+                emailAddress?: string;
+
+                @jf.string().min(8).required()
+                password?: string;
+            }
+
+            expect(jf.hasSchema(Login)).toBe(true);
+        });
     });
 });
 

--- a/test/unit/testUtil.ts
+++ b/test/unit/testUtil.ts
@@ -5,6 +5,13 @@ import * as fs from 'fs';
 import { Validator } from '../../src/validation';
 import { AnyClass, getJoiSchema, getJoi, parseVersionString } from '../../src/core';
 
+export function notNil<T>(value: T): Exclude<T, null | undefined> {
+    if (value === null || value === undefined) {
+        throw new Error('Unexpected nil value');
+    }
+    return value as Exclude<T, null | undefined>;
+}
+
 export function testConstraint<T>(
     classFactory: () => { new(...args: any[]): T },
     valid: T[],


### PR DESCRIPTION
## Summary
- Added `getSchema` to `Joiful` class and exported it from the default instance in `index.ts`

  - `getSchema` simply calls existing internal `getJoiSchema` function

  - Changed the default behaviour of `getJoiSchema` to return `undefined` rather than an empty object schema if there is no working schema for the given class or it's ancestors.

- Added `hasSchema` to `Joiful` class and exported it from the default instance in `index.ts`

  - Simply returns boolean for whether a class has a schema (any decorators) or not.

- Changed the default behaviour of the validator functions (`validate`, `validateAsClass`, `validateArrayAsClass`) so that they will error (with `NoValidationSchemaForClassError`) when trying to validate against a class that has no schema associated with it. This will be a breaking change and will trigger a major version bump when releasing.

## Motivation
@stepanzabelin wanted a way to tell if a class has a schema associated with it (see #105). This PR addresses this issue by exporting a `hasSchema` function that returns whether a class has a schema or not.

## Ticket
Closes #105.