### PR TITLE
fix(validation): issue #117: validator now accepts custom joi

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "get-root-path": "2.0.2",
         "husky": "4.2.1",
         "jest": "24.9.0",
+        "jest-helpers": "3.1.1",
         "lodash": "4.17.15",
         "reflect-metadata": "0.1.13",
         "rimraf": "3.0.2",

--- a/src/core.ts
+++ b/src/core.ts
@@ -94,7 +94,7 @@ export function getMergedWorkingSchemas(target: object): WorkingSchema | undefin
     return undefined;
 }
 
-export function getJoiSchema(Class: AnyClass, joi: typeof Joi): Joi.ObjectSchema | undefined {
+export function getJoiSchema(Class: AnyClass, joi: Pick<typeof Joi, 'object'>): Joi.ObjectSchema | undefined {
     const isSchemaDefined = Reflect.hasOwnMetadata(SCHEMA_KEY, Class.prototype);
     if (isSchemaDefined) {
         return Reflect.getOwnMetadata(SCHEMA_KEY, Class.prototype);

--- a/test/unit/core.test.ts
+++ b/test/unit/core.test.ts
@@ -1,6 +1,7 @@
 import * as Joi from '@hapi/joi';
 import * as jf from '../../src';
 import {
+    getJoi,
     getJoiSchema,
     getJoiVersion,
     JOI_VERSION,
@@ -23,6 +24,30 @@ describe('checkJoiIsCompatible', () => {
 
     it('should not error if no joi instance is passed in', () => {
         checkJoiIsCompatible(undefined);
+    });
+});
+
+describe('getJoi', () => {
+    it('should return the default Joi instance when no options are passed', () => {
+        expect(getJoi()).toBe(Joi);
+    });
+
+    it('should return the default Joi instance when given undefined', () => {
+        expect(getJoi(undefined)).toBe(Joi);
+    });
+
+    it('should return the default Joi instance when given an empty object', () => {
+        expect(getJoi({})).toBe(Joi);
+    });
+
+    it('should return the given Joi instance', () => {
+        const customJoi = Joi.extend({
+            base: Joi.string(),
+            name: 'string',
+        });
+        const result = getJoi({ joi: customJoi });
+        expect(result).toBe(customJoi);
+        expect(result).not.toBe(Joi);
     });
 });
 

--- a/test/unit/validation.test.ts
+++ b/test/unit/validation.test.ts
@@ -10,6 +10,7 @@ import {
     isValidationFail,
 } from '../../src';
 import { InvalidValidationTarget, NoValidationSchemaForClassError } from '../../src/validation';
+import { AnyClass } from '../../src/core';
 
 interface ResetPasswordForm {
     emailAddress?: string;
@@ -69,71 +70,137 @@ describe('ValidationResult', () => {
 });
 
 describe('Validation', () => {
-    class Login {
-        @string()
-        emailAddress?: string;
+    type ValidatorLike = Pick<Validator, 'validate' | 'validateAsClass' | 'validateArrayAsClass'>;
 
-        @string()
+    let login: {
+        emailAddress?: string;
         password?: string;
+    };
+    let Login: AnyClass;
+    let dummyArrayItemSchema = Object.freeze({});
+    let dummySchema = Object.freeze({});
+    let mockJoi: {
+        array: jest.MockedFunction<typeof Joi['array']>;
+        object: jest.MockedFunction<typeof Joi['object']>;
+        validate: jest.MockedFunction<typeof Joi['validate']>;
+    };
+
+    function createMockJoi() {
+        return {
+            array: jest.fn().mockReturnValue({
+                items: jest.fn().mockReturnValue(dummyArrayItemSchema), // required for `validateArrayAsClass()`
+            }),
+            object: jest.fn().mockReturnValue({
+                keys: jest.fn().mockReturnValue(dummySchema), // required for `getJoiSchema()`
+            }),
+            validate: jest.fn(),
+        };
     }
 
-    let login: Login;
+    function mockJoiValidateSuccess<T>(value: T) {
+        mockJoi.validate.mockReturnValueOnce({
+            error: null,
+            value,
+        });
+    }
+
+    function assertMockJoiValidateInvocation<T>(value: T, expectedSchema: Readonly<{}> = dummySchema) {
+        expect(mockJoi.validate.mock.calls.length).toEqual(1);
+        expect(mockJoi.validate.mock.calls[0]).toEqual([value, expectedSchema, {}]);
+    }
+
+    function assertValidateSuccess<T>(result: ValidationResult<T>, expectedValue: T) {
+        expect(result.value).toEqual(expectedValue);
+        expect(result.error).toBe(null);
+    }
+
+    function assertValidateFailure<T>(result: ValidationResult<T>, expectedValue: T) {
+        expect(result.value).toEqual(expectedValue);
+        expect(result.error).toBeTruthy();
+    }
 
     beforeEach(() => {
-        login = new Login();
+        // Define the class for each test, so that the schema is re-created every time.
+        class LoginClass {
+            @string()
+            emailAddress?: string;
+
+            @string()
+            password?: string;
+        }
+        login = new LoginClass();
         login.emailAddress = 'joe@example.com';
+        Login = LoginClass;
+        mockJoi = createMockJoi();
     });
 
-    describe('Validator', () => {
-        let validator: Validator;
+    afterEach(() => {
+        mockJoi.array.mockReset();
+        mockJoi.object.mockReset();
+        mockJoi.validate.mockReset();
+    });
 
-        beforeEach(() => {
-            validator = new Validator();
+    describe('Validator constructor', () => {
+        it('should use validation options of the Joi instance by default', () => {
+            const validator = new Validator();
+            const result = validator.validate(login);
+            assertValidateSuccess(result, login);
         });
 
-        describe('constructor', () => {
-            it('should use validation options of the Joi instance by default', () => {
-                const result = validator.validate(login);
-                expect(result.value).toEqual(login);
-                expect(result.error).toBe(null);
-            });
+        it('should optionally accept validation options to use', () => {
+            const validator = new Validator({ presence: 'required' });
+            const result = validator.validate(login);
+            assertValidateFailure(result, login);
+        });
 
-            it('should optionally accept validation options to use', () => {
-                validator = new Validator({ presence: 'required' });
-                const result = validator.validate(login);
-                expect(result.value).toEqual(login);
-                expect(result.error).toBeTruthy();
+        it('should support a custom instance of Joi', () => {
+            mockJoiValidateSuccess(login);
+            const validator = new Validator({
+                joi: mockJoi,
             });
+            const result = validator.validate(login);
+            assertValidateSuccess(result, login);
+            assertMockJoiValidateInvocation(login);
+        });
+    });
 
-            it('should support a custom instance of Joi', () => {
-                validator = new Validator({
-                    joi: Joi,
-                });
-                const result = validator.validate(login);
-                expect(result.value).toEqual(login);
-                expect(result.error).toBe(null);
-            });
+    describe.each([
+        ['new instance', () => new Validator()],
+        ['default instance', () => ({
+            validate,
+            validateAsClass,
+            validateArrayAsClass,
+        })],
+    ] as [string, () => ValidatorLike][])(
+        'Validator - %s',
+        (
+            _testSuiteDescription: string,
+            validatorFactory: () => Pick<Validator, 'validate' | 'validateAsClass' | 'validateArrayAsClass'>,
+    ) => {
+        let validator: ValidatorLike;
+
+        beforeEach(() => {
+            validator = validatorFactory();
         });
 
         describe('validate', () => {
             it('should validate an instance of a decorated class', () => {
                 const result = validator.validate(login);
-                expect(result.value).toEqual(login);
-                expect(result.error).toBe(null);
+                assertValidateSuccess(result, login);
             });
 
             it('should optionally accept validation options to use', () => {
                 const result = validator.validate(login, { presence: 'required' });
-                expect(result.value).toEqual(login);
-                expect(result.error).toBeTruthy();
+                assertValidateFailure(result, login);
             });
 
             it('should support a custom instance of Joi', () => {
+                mockJoiValidateSuccess(login);
                 const result = validator.validate(login, {
-                    joi: Joi,
+                    joi: mockJoi,
                 });
-                expect(result.value).toEqual(login);
-                expect(result.error).toBe(null);
+                assertValidateSuccess(result, login);
+                assertMockJoiValidateInvocation(login);
             });
 
             it('should error when trying to validate null', () => {
@@ -144,22 +211,22 @@ describe('Validation', () => {
         describe('validateAsClass', () => {
             it('should accept a plain old javascript object to validate', () => {
                 const result = validator.validateAsClass({ ...login }, Login);
-                expect(result.value).toEqual(login);
-                expect(result.error).toBe(null);
+                assertValidateSuccess(result, login);
             });
 
             it('should optionally accept validation options to use', () => {
                 const result = validator.validateAsClass({ ...login }, Login, { presence: 'required' });
-                expect(result.value).toEqual(login);
-                expect(result.error).toBeTruthy();
+                assertValidateFailure(result, login);
             });
 
             it('should support a custom instance of Joi', () => {
-                const result = validator.validateAsClass({ ...login }, Login, {
-                    joi: Joi,
+                const inputValue = { ...login };
+                mockJoiValidateSuccess(inputValue);
+                const result = validator.validateAsClass(inputValue, Login, {
+                    joi: mockJoi,
                 });
-                expect(result.value).toEqual(login);
-                expect(result.error).toBe(null);
+                assertValidateSuccess(result, login);
+                assertMockJoiValidateInvocation(inputValue);
             });
 
             it('should error when trying to validate null', () => {
@@ -183,22 +250,22 @@ describe('Validation', () => {
         describe('validateArrayAsClass', () => {
             it('should accept an array of plain old javascript objects to validate', () => {
                 const result = validator.validateArrayAsClass([{ ...login }], Login);
-                expect(result.value).toEqual([login]);
-                expect(result.error).toBe(null);
+                assertValidateSuccess(result, [login]);
             });
 
             it('should optionally accept validation options to use', () => {
                 const result = validator.validateArrayAsClass([{ ...login }], Login, { presence: 'required' });
-                expect(result.value).toEqual([login]);
-                expect(result.error).toBeTruthy();
+                assertValidateFailure(result, [login]);
             });
 
             it('should support a custom instance of Joi', () => {
-                const result = validator.validateArrayAsClass([{ ...login }], Login, {
-                    joi: Joi,
+                const inputValue = [{ ...login }];
+                mockJoiValidateSuccess(inputValue);
+                const result = validator.validateArrayAsClass(inputValue, Login, {
+                    joi: mockJoi,
                 });
-                expect(result.value).toEqual([login]);
-                expect(result.error).toBe(null);
+                assertValidateSuccess(result, [login]);
+                assertMockJoiValidateInvocation(inputValue, dummyArrayItemSchema);
             });
 
             it('should error when trying to validate null', () => {
@@ -222,83 +289,50 @@ describe('Validation', () => {
         });
     });
 
-    describe('validate', () => {
-        it('should validate an instance of a decorated class', () => {
-            const result = validate(login);
-            expect(result.value).toEqual(login);
-            expect(result.error).toBe(null);
-        });
-
-        it('should optionally accept validation options to use', () => {
-            const result = validate(login, { presence: 'required' });
-            expect(result.value).toEqual(login);
-            expect(result.error).toBeTruthy();
-        });
-
-        it('should support a custom instance of Joi', () => {
-            const result = validate(login, {
-                joi: Joi,
+    describe('On-demand schema generation', () => {
+        it('should only convert working schema to a final schema once - validate', () => {
+            expect(mockJoi.object.mock.calls.length).toEqual(0);
+            mockJoiValidateSuccess(login);
+            validate(login, {
+                joi: mockJoi,
             });
-            expect(result.value).toEqual(login);
-            expect(result.error).toBe(null);
-        });
-
-        it('should error when trying to validate null', () => {
-            expect(() => validate(null)).toThrowError(new InvalidValidationTarget());
-        });
-    });
-
-    describe('validateAsClass', () => {
-        it('should accept a plain old javascript object to validate', () => {
-            const result = validateAsClass({ ...login }, Login);
-            expect(result.value).toEqual(login);
-            expect(result.error).toBe(null);
-        });
-
-        it('should optionally accept validation options to use', () => {
-            const result = validateAsClass({ ...login }, Login, { presence: 'required' });
-            expect(result.value).toEqual(login);
-            expect(result.error).toBeTruthy();
-        });
-
-        it('should support a custom instance of Joi', () => {
-            const result = validateAsClass({ ...login }, Login, {
-                joi: Joi,
+            expect(mockJoi.object.mock.calls.length).toEqual(1);
+            mockJoiValidateSuccess(login);
+            validate(login, {
+                joi: mockJoi,
             });
-            expect(result.value).toEqual(login);
-            expect(result.error).toBe(null);
+            expect(mockJoi.object.mock.calls.length).toEqual(1);
         });
 
-        it('should error when trying to validate null', () => {
-            expect(() => validateAsClass(null, Login)).toThrowError(new InvalidValidationTarget());
-        });
-    });
-
-    describe('validateArrayAsClass', () => {
-        it('should accept an array of plain old javascript objects to validate', () => {
-            const result = validateArrayAsClass([{ ...login }], Login);
-            expect(result.value).toEqual([login]);
-            expect(result.error).toBe(null);
-        });
-
-        it('should optionally accept validation options to use', () => {
-            const result = validateArrayAsClass([{ ...login }], Login, { presence: 'required' });
-            expect(result.value).toEqual([login]);
-            expect(result.error).toBeTruthy();
-        });
-
-        it('should support a custom instance of Joi', () => {
-            const result = validateArrayAsClass([{ ...login }], Login, {
-                joi: Joi,
+        it('should only convert working schema to a final schema once - validateAsClass', () => {
+            expect(mockJoi.object.mock.calls.length).toEqual(0);
+            mockJoiValidateSuccess(login);
+            validateAsClass(login, Login, {
+                joi: mockJoi,
             });
-            expect(result.value).toEqual([login]);
-            expect(result.error).toBe(null);
+            expect(mockJoi.object.mock.calls.length).toEqual(1);
+            mockJoiValidateSuccess(login);
+            validateAsClass(login, Login, {
+                joi: mockJoi,
+            });
+            expect(mockJoi.object.mock.calls.length).toEqual(1);
         });
 
-        it('should error when trying to validate null', () => {
-            expect(
-                () => validateArrayAsClass(null as any, Login),
-            ).toThrowError(new InvalidValidationTarget());
+        it('should only convert working schema to a final schema once, and always creates a new array schema - validateArrayAsClass', () => {
+            expect(mockJoi.object.mock.calls.length).toEqual(0);
+            expect(mockJoi.array.mock.calls.length).toEqual(0);
+            mockJoiValidateSuccess([login]);
+            validateArrayAsClass([login], Login, {
+                joi: mockJoi,
+            });
+            expect(mockJoi.object.mock.calls.length).toEqual(1);
+            expect(mockJoi.array.mock.calls.length).toEqual(1);
+            mockJoiValidateSuccess([login]);
+            validateArrayAsClass([login], Login, {
+                joi: mockJoi,
+            });
+            expect(mockJoi.object.mock.calls.length).toEqual(1);
+            expect(mockJoi.array.mock.calls.length).toEqual(2);
         });
     });
 });

--- a/test/unit/validation.test.ts
+++ b/test/unit/validation.test.ts
@@ -1,3 +1,4 @@
+import * as Joi from '@hapi/joi';
 import {
     string,
     validate,
@@ -103,6 +104,15 @@ describe('Validation', () => {
                 expect(result.value).toEqual(login);
                 expect(result.error).toBeTruthy();
             });
+
+            it('should support a custom instance of Joi', () => {
+                validator = new Validator({
+                    joi: Joi,
+                });
+                const result = validator.validate(login);
+                expect(result.value).toEqual(login);
+                expect(result.error).toBe(null);
+            });
         });
 
         describe('validate', () => {
@@ -116,6 +126,14 @@ describe('Validation', () => {
                 const result = validator.validate(login, { presence: 'required' });
                 expect(result.value).toEqual(login);
                 expect(result.error).toBeTruthy();
+            });
+
+            it('should support a custom instance of Joi', () => {
+                const result = validator.validate(login, {
+                    joi: Joi,
+                });
+                expect(result.value).toEqual(login);
+                expect(result.error).toBe(null);
             });
 
             it('should error when trying to validate null', () => {
@@ -134,6 +152,14 @@ describe('Validation', () => {
                 const result = validator.validateAsClass({ ...login }, Login, { presence: 'required' });
                 expect(result.value).toEqual(login);
                 expect(result.error).toBeTruthy();
+            });
+
+            it('should support a custom instance of Joi', () => {
+                const result = validator.validateAsClass({ ...login }, Login, {
+                    joi: Joi,
+                });
+                expect(result.value).toEqual(login);
+                expect(result.error).toBe(null);
             });
 
             it('should error when trying to validate null', () => {
@@ -165,6 +191,14 @@ describe('Validation', () => {
                 const result = validator.validateArrayAsClass([{ ...login }], Login, { presence: 'required' });
                 expect(result.value).toEqual([login]);
                 expect(result.error).toBeTruthy();
+            });
+
+            it('should support a custom instance of Joi', () => {
+                const result = validator.validateArrayAsClass([{ ...login }], Login, {
+                    joi: Joi,
+                });
+                expect(result.value).toEqual([login]);
+                expect(result.error).toBe(null);
             });
 
             it('should error when trying to validate null', () => {
@@ -201,6 +235,14 @@ describe('Validation', () => {
             expect(result.error).toBeTruthy();
         });
 
+        it('should support a custom instance of Joi', () => {
+            const result = validate(login, {
+                joi: Joi,
+            });
+            expect(result.value).toEqual(login);
+            expect(result.error).toBe(null);
+        });
+
         it('should error when trying to validate null', () => {
             expect(() => validate(null)).toThrowError(new InvalidValidationTarget());
         });
@@ -219,6 +261,14 @@ describe('Validation', () => {
             expect(result.error).toBeTruthy();
         });
 
+        it('should support a custom instance of Joi', () => {
+            const result = validateAsClass({ ...login }, Login, {
+                joi: Joi,
+            });
+            expect(result.value).toEqual(login);
+            expect(result.error).toBe(null);
+        });
+
         it('should error when trying to validate null', () => {
             expect(() => validateAsClass(null, Login)).toThrowError(new InvalidValidationTarget());
         });
@@ -235,6 +285,14 @@ describe('Validation', () => {
             const result = validateArrayAsClass([{ ...login }], Login, { presence: 'required' });
             expect(result.value).toEqual([login]);
             expect(result.error).toBeTruthy();
+        });
+
+        it('should support a custom instance of Joi', () => {
+            const result = validateArrayAsClass([{ ...login }], Login, {
+                joi: Joi,
+            });
+            expect(result.value).toEqual([login]);
+            expect(result.error).toBe(null);
         });
 
         it('should error when trying to validate null', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2637,6 +2637,11 @@ jest-haste-map@^24.9.0:
   optionalDependencies:
     fsevents "^1.2.7"
 
+jest-helpers@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/jest-helpers/-/jest-helpers-3.1.1.tgz#916f34b9518178c321797b12c5bb3c58e11d8b9f"
+  integrity sha512-lQj7qTsYWSwOsZn2Uy9VkurzLpREluEf2dnXCT4d/K1oZt4jzLsGsVzb2nejW1FVJ0JvGeImcpVgERlXL0gvEw==
+
 jest-jasmine2@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz#1f7b1bd3242c1774e62acabb3646d96afc3be6a0"


### PR DESCRIPTION
This fixes an issue where the Joiful Validator's options are passed to the Joi validate() method, which validates its options, and rejects our additional property of `joi`.

Also, add unit tests for `getJoi()`; because Validator no longer uses it, we lost some coverage.

Closes #117 